### PR TITLE
NodeSet resource

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@
 
 # Project-local glide cache, RE: https://github.com/Masterminds/glide/issues/736
 .glide/
+
+*.img

--- a/cmd/placemat/yaml.go
+++ b/cmd/placemat/yaml.go
@@ -16,7 +16,7 @@ type baseConfig struct {
 
 type nodeSpec struct {
 	Interfaces []string `yaml:"interfaces"`
-	Volumes []struct {
+	Volumes    []struct {
 		Name           string `yaml:"name"`
 		Size           string `yaml:"size"`
 		RecreatePolicy string `yaml:"recreatePolicy"`

--- a/cmd/placemat/yaml.go
+++ b/cmd/placemat/yaml.go
@@ -59,7 +59,7 @@ func unmarshalNode(data []byte) (*placemat.Node, error) {
 	if err != nil {
 		return nil, err
 	}
-	node.Spec = *s
+	node.Spec = s
 
 	return &node, err
 }
@@ -82,7 +82,7 @@ func unmarshalNodeSet(data []byte) (*placemat.NodeSet, error) {
 	return &nodeSet, err
 }
 
-func constructNodeSpec(ns nodeSpec) (*placemat.NodeSpec, error) {
+func constructNodeSpec(ns nodeSpec) (placemat.NodeSpec, error) {
 	var res placemat.NodeSpec
 	res.Interfaces = ns.Interfaces
 	if ns.Interfaces == nil {
@@ -98,11 +98,11 @@ func constructNodeSpec(ns nodeSpec) (*placemat.NodeSpec, error) {
 		var ok bool
 		dst.RecreatePolicy, ok = recreatePolicyConfig[v.RecreatePolicy]
 		if !ok {
-			return nil, errors.New("Invalid RecreatePolicy: " + v.RecreatePolicy)
+			return res, errors.New("Invalid RecreatePolicy: " + v.RecreatePolicy)
 		}
 	}
 
-	return &res, nil
+	return res, nil
 }
 
 func readYaml(r *bufio.Reader) (*placemat.Cluster, error) {

--- a/cmd/placemat/yaml.go
+++ b/cmd/placemat/yaml.go
@@ -61,7 +61,7 @@ func unmarshalNode(data []byte) (*placemat.Node, error) {
 	}
 	node.Spec = s
 
-	return &node, err
+	return &node, nil
 }
 
 func unmarshalNodeSet(data []byte) (*placemat.NodeSet, error) {
@@ -98,7 +98,7 @@ func constructNodeSpec(ns nodeSpec) (placemat.NodeSpec, error) {
 		var ok bool
 		dst.RecreatePolicy, ok = recreatePolicyConfig[v.RecreatePolicy]
 		if !ok {
-			return res, errors.New("Invalid RecreatePolicy: " + v.RecreatePolicy)
+			return placemat.NodeSpec{}, errors.New("Invalid RecreatePolicy: " + v.RecreatePolicy)
 		}
 	}
 

--- a/cmd/placemat/yaml_test.go
+++ b/cmd/placemat/yaml_test.go
@@ -102,7 +102,7 @@ spec:
 				Name: "worker",
 				Spec: placemat.NodeSetSpec{
 					Replicas: 3,
-					Template: &placemat.NodeSpec{
+					Template: placemat.NodeSpec{
 						Interfaces: []string{"my-net"},
 						Volumes: []*placemat.VolumeSpec{
 							{Name: "data", Size: "10GB", RecreatePolicy: placemat.RecreateIfNotPresent},

--- a/resource.go
+++ b/resource.go
@@ -36,8 +36,17 @@ type Node struct {
 	Spec NodeSpec
 }
 
+// NodeSetSpec represents a node-set specification
+type NodeSetSpec struct {
+	Replicas int
+	Template *NodeSpec
+}
+
 // NodeSet represents a node-set configuration
-type NodeSet struct{}
+type NodeSet struct {
+	Name     string
+	Spec NodeSetSpec
+}
 
 // Cluster represents cluster configuration
 type Cluster struct {
@@ -48,6 +57,8 @@ type Cluster struct {
 
 // Append appends the other cluster into the receiver
 func (c *Cluster) Append(other *Cluster) *Cluster {
+	c.Networks = append(c.Networks, other.Networks...)
 	c.Nodes = append(c.Nodes, other.Nodes...)
+	c.NodeSets = append(c.NodeSets, other.NodeSets...)
 	return c
 }

--- a/resource.go
+++ b/resource.go
@@ -44,7 +44,7 @@ type NodeSetSpec struct {
 
 // NodeSet represents a node-set configuration
 type NodeSet struct {
-	Name     string
+	Name string
 	Spec NodeSetSpec
 }
 

--- a/resource.go
+++ b/resource.go
@@ -39,7 +39,7 @@ type Node struct {
 // NodeSetSpec represents a node-set specification
 type NodeSetSpec struct {
 	Replicas int
-	Template *NodeSpec
+	Template NodeSpec
 }
 
 // NodeSet represents a node-set configuration

--- a/server.go
+++ b/server.go
@@ -2,7 +2,7 @@ package placemat
 
 import (
 	"context"
-
+	"strconv"
 	"github.com/cybozu-go/cmd"
 )
 
@@ -15,8 +15,21 @@ type Provider interface {
 	StartNode(ctx context.Context, n *Node) error
 }
 
-func createNodeVolumes(ctx context.Context, provider Provider, cluster *Cluster) error {
-	for _, n := range cluster.Nodes {
+func interpretNodesFromNodeSet(ctx context.Context, provider Provider, cluster *Cluster) []*Node {
+	var nodes []*Node
+	for _, nodeSet := range cluster.NodeSets {
+		for i := 1; i <= nodeSet.Spec.Replicas; i++ {
+			var node Node
+			node.Name = nodeSet.Name + "-" + strconv.Itoa(i)
+			node.Spec = *nodeSet.Spec.Template
+			nodes = append(nodes, &node)
+		}
+	}
+	return nodes
+}
+
+func createNodeVolumes(ctx context.Context, provider Provider, nodes []*Node) error {
+	for _, n := range nodes {
 		for _, v := range n.Spec.Volumes {
 			exists, err := provider.VolumeExists(ctx, n.Name, v.Name)
 			if err != nil {
@@ -35,9 +48,9 @@ func createNodeVolumes(ctx context.Context, provider Provider, cluster *Cluster)
 	return nil
 }
 
-func startNodes(ctx context.Context, provider Provider, cluster *Cluster) error {
+func startNodes(ctx context.Context, provider Provider, nodes []*Node) error {
 	env := cmd.NewEnvironment(ctx)
-	for _, n := range cluster.Nodes {
+	for _, n := range nodes {
 		node := n
 		env.Go(func(ctx context.Context) error {
 			return provider.StartNode(ctx, node)
@@ -49,10 +62,13 @@ func startNodes(ctx context.Context, provider Provider, cluster *Cluster) error 
 
 // Run runs VMs described in cluster by provider
 func Run(ctx context.Context, provider Provider, cluster *Cluster) error {
-	err := createNodeVolumes(ctx, provider, cluster)
+	nodes := interpretNodesFromNodeSet(ctx, provider, cluster)
+	nodes = append(nodes, cluster.Nodes...)
+
+	err := createNodeVolumes(ctx, provider, nodes)
 	if err != nil {
 		return err
 	}
 
-	return startNodes(ctx, provider, cluster)
+	return startNodes(ctx, provider, nodes)
 }

--- a/server.go
+++ b/server.go
@@ -15,13 +15,13 @@ type Provider interface {
 	StartNode(ctx context.Context, n *Node) error
 }
 
-func interpretNodesFromNodeSet(ctx context.Context, provider Provider, cluster *Cluster) []*Node {
+func interpretNodesFromNodeSet(cluster *Cluster) []*Node {
 	var nodes []*Node
 	for _, nodeSet := range cluster.NodeSets {
 		for i := 1; i <= nodeSet.Spec.Replicas; i++ {
 			var node Node
 			node.Name = nodeSet.Name + "-" + strconv.Itoa(i)
-			node.Spec = *nodeSet.Spec.Template
+			node.Spec = nodeSet.Spec.Template
 			nodes = append(nodes, &node)
 		}
 	}
@@ -62,7 +62,7 @@ func startNodes(ctx context.Context, provider Provider, nodes []*Node) error {
 
 // Run runs VMs described in cluster by provider
 func Run(ctx context.Context, provider Provider, cluster *Cluster) error {
-	nodes := interpretNodesFromNodeSet(ctx, provider, cluster)
+	nodes := interpretNodesFromNodeSet(cluster)
 	nodes = append(nodes, cluster.Nodes...)
 
 	err := createNodeVolumes(ctx, provider, nodes)

--- a/server.go
+++ b/server.go
@@ -2,8 +2,8 @@ package placemat
 
 import (
 	"context"
-	"strconv"
 	"github.com/cybozu-go/cmd"
+	"strconv"
 )
 
 // Provider represents a back-end of VM engine

--- a/server.go
+++ b/server.go
@@ -2,8 +2,9 @@ package placemat
 
 import (
 	"context"
-	"github.com/cybozu-go/cmd"
 	"strconv"
+
+	"github.com/cybozu-go/cmd"
 )
 
 // Provider represents a back-end of VM engine

--- a/server_test.go
+++ b/server_test.go
@@ -2,10 +2,11 @@ package placemat
 
 import (
 	"context"
-	"github.com/cybozu-go/cmd"
 	"strconv"
 	"sync"
 	"testing"
+
+	"github.com/cybozu-go/cmd"
 )
 
 type MockProvider struct {

--- a/server_test.go
+++ b/server_test.go
@@ -2,9 +2,9 @@ package placemat
 
 import (
 	"context"
+	"strconv"
 	"sync"
 	"testing"
-	"strconv"
 )
 
 type MockProvider struct {


### PR DESCRIPTION
This PR introduces **NodeSet** resouce.

The properties (spec) that can be defined in the NodeSet resource are as follows.

- `replicas`: number of nodes to create
- `template`: Specify a template to be applied to the spec of the Node resource.


NodeSet creates `spec.replicas` Nodes.
Each Node's name is `"${name}-$i"` (`i` is a serial number).

In the `spec.template`, describe the spec of the Node resource.

---

In the example below, nodes of `worker-1`, `worker-2`, `worker-3` are created.

```yaml
# nodeset.yaml
kind: NodeSet
name: worker
spec:
  replicas: 3
  template:
    interfaces:
      - my-net
    volumes:
      - name: data
        size: 10GB
```