### PR TITLE
Network resource

### DIFF
--- a/cmd/placemat/yaml_test.go
+++ b/cmd/placemat/yaml_test.go
@@ -9,6 +9,52 @@ import (
 	"github.com/cybozu-go/placemat"
 )
 
+func TestUnmarshalNetwork(t *testing.T) {
+	cases := []struct {
+		source string
+
+		expected placemat.Network
+	}{
+		{
+			source: `
+kind: Network
+name: net1
+spec:
+  addresses:
+    - 10.0.0.1
+    - 10.0.0.2
+`,
+			expected: placemat.Network{
+				Name: "net1",
+				Spec: placemat.NetworkSpec{
+					Addresses: []string{"10.0.0.1", "10.0.0.2"},
+				},
+			},
+		},
+		{
+			source: `
+
+kind: Network
+name: net2
+`,
+			expected: placemat.Network{
+				Name: "net2",
+				Spec: placemat.NetworkSpec{},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		actual, err := unmarshalNetwork([]byte(c.source))
+		if err != nil {
+			t.Error(err)
+		}
+		if !reflect.DeepEqual(*actual, c.expected) {
+			t.Errorf("%v != %v", *actual, c.expected)
+		}
+	}
+}
+
 func TestUnmarshalNode(t *testing.T) {
 	cases := []struct {
 		source string
@@ -82,6 +128,9 @@ spec:
 
 func TestUnmarshalCluster(t *testing.T) {
 	yaml := `
+kind: Network
+name: net1
+---
 kind: Node
 name: node1
 ---
@@ -92,6 +141,9 @@ name: node2
 	cluster, err := readYaml(bufio.NewReader(bytes.NewReader([]byte(yaml))))
 	if err != nil {
 		t.Error(err)
+	}
+	if len(cluster.Networks) != 1 {
+		t.Error("len(cluster.Networks) != 2, ", len(cluster.Networks))
 	}
 	if len(cluster.Nodes) != 2 {
 		t.Error("len(cluster.Nodes) != 2, ", len(cluster.Nodes))

--- a/cmd/placemat/yaml_test.go
+++ b/cmd/placemat/yaml_test.go
@@ -143,7 +143,7 @@ name: node2
 		t.Error(err)
 	}
 	if len(cluster.Networks) != 1 {
-		t.Error("len(cluster.Networks) != 2, ", len(cluster.Networks))
+		t.Error("len(cluster.Networks) != 1, ", len(cluster.Networks))
 	}
 	if len(cluster.Nodes) != 2 {
 		t.Error("len(cluster.Nodes) != 2, ", len(cluster.Nodes))

--- a/qemu.go
+++ b/qemu.go
@@ -26,6 +26,9 @@ func createTap(ctx context.Context, tap string, network string) error {
 		return err
 	}
 	err = cmd.CommandContext(ctx, "ip", "link", "set", tap, "master", network).Run()
+	if err != nil {
+		return err
+	}
 	return cmd.CommandContext(ctx, "ip", "link", "set", tap, "up").Run()
 }
 

--- a/qemu.go
+++ b/qemu.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path"
+	"time"
 
 	"github.com/cybozu-go/cmd"
 	"github.com/cybozu-go/log"
@@ -109,13 +110,17 @@ func (q QemuProvider) StartNode(ctx context.Context, n *Node) error {
 
 	for _, br := range n.Spec.Interfaces {
 		tap := n.Name + "_" + br
-		err := deleteTap(context.Background(), tap)
-		if err != nil {
-			log.Error("Failed to delete a TAP", map[string]interface{}{
-				"name":  tap,
-				"error": err,
-			})
-		}
+		func() {
+			ctx2, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer cancel()
+			err := deleteTap(ctx2, tap)
+			if err != nil {
+				log.Error("Failed to delete a TAP", map[string]interface{}{
+					"name":  tap,
+					"error": err,
+				})
+			}
+		}()
 	}
 	return nil
 }

--- a/qemu.go
+++ b/qemu.go
@@ -89,7 +89,7 @@ func (q QemuProvider) CreateNetwork(ctx context.Context, net *Network) error {
 	return nil
 }
 
-// DestroyNetwork destroies a bridge by the name
+// DestroyNetwork destroys a bridge by the name
 func (q QemuProvider) DestroyNetwork(ctx context.Context, name string) error {
 	c := cmd.CommandContext(ctx, "ip", "link", "delete", name, "type", "bridge")
 	log.Info("Destroying network", map[string]interface{}{"name": name})

--- a/qemu.go
+++ b/qemu.go
@@ -15,6 +15,24 @@ type QemuProvider struct {
 	BaseDir string
 }
 
+func createTap(ctx context.Context, tap string, network string) error {
+	log.Info("Creating TAP", map[string]interface{}{"name": tap})
+	err := cmd.CommandContext(ctx, "ip", "tuntap", "add", tap, "mode", "tap").Run()
+	if err != nil {
+		return err
+	}
+	err = cmd.CommandContext(ctx, "ip", "link", "set", tap, "master", network).Run()
+	if err != nil {
+		return err
+	}
+	err = cmd.CommandContext(ctx, "ip", "link", "set", tap, "master", network).Run()
+	return cmd.CommandContext(ctx, "ip", "link", "set", tap, "up").Run()
+}
+
+func deleteTap(ctx context.Context, tap string) error {
+	return cmd.CommandContext(ctx, "ip", "tuntap", "delete", tap, "mode", "tap").Run()
+}
+
 func (q QemuProvider) volumePath(host, name string) string {
 	return path.Join(q.BaseDir, host+"_"+name+".img")
 }
@@ -28,9 +46,18 @@ func (q QemuProvider) VolumeExists(ctx context.Context, node, vol string) (bool,
 
 // CreateNetwork creates a bridge by the Network
 func (q QemuProvider) CreateNetwork(ctx context.Context, net *Network) error {
-	c := cmd.CommandContext(ctx, "ip", "link", "add", net.Name, "type", "bridge")
-	log.Info("Creating network", map[string]interface{}{"name": net.Name})
-	return c.Run()
+	log.Info("Creating network", map[string]interface{}{"name": net.Name, "spec": net})
+	err := cmd.CommandContext(ctx, "ip", "link", "add", net.Name, "type", "bridge").Run()
+	if err != nil {
+		return err
+	}
+	for _, addr := range net.Spec.Addresses {
+		err := cmd.CommandContext(ctx, "ip", "addr", "add", addr, "dev", net.Name).Run()
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // DestroyNetwork destroies a bridge by the name
@@ -51,10 +78,37 @@ func (q QemuProvider) CreateVolume(ctx context.Context, node string, vol *Volume
 // StartNode starts a QEMU vm
 func (q QemuProvider) StartNode(ctx context.Context, n *Node) error {
 	params := []string{"-enable-kvm"}
+
+	for _, br := range n.Spec.Interfaces {
+		tap := n.Name + "_" + br
+		err := createTap(ctx, tap, br)
+		if err != nil {
+			return err
+		}
+
+		params = append(params, "-netdev", "tap,id="+br+",ifname="+tap+",script=no,downscript=no")
+		params = append(params, "-device", "virtio-net-pci,netdev="+br+",romfile=")
+	}
 	for _, v := range n.Spec.Volumes {
 		p := q.volumePath(n.Name, v.Name)
-		params = append(params, "-drive")
-		params = append(params, "if=virtio,cache=none,aio=native,file="+p)
+		params = append(params, "-drive", "if=virtio,cache=none,aio=native,file="+p)
 	}
-	return cmd.CommandContext(ctx, "qemu-system-x86_64", params...).Run()
+	err := cmd.CommandContext(ctx, "qemu-system-x86_64", params...).Run()
+	if err != nil {
+		log.Error("QEMU exited with an error", map[string]interface{}{
+			"error": err,
+		})
+	}
+
+	for _, br := range n.Spec.Interfaces {
+		tap := n.Name + "_" + br
+		err := deleteTap(context.Background(), tap)
+		if err != nil {
+			log.Error("Failed to delete a TAP", map[string]interface{}{
+				"name":  tap,
+				"error": err,
+			})
+		}
+	}
+	return nil
 }

--- a/qemu.go
+++ b/qemu.go
@@ -26,6 +26,20 @@ func (q QemuProvider) VolumeExists(ctx context.Context, node, vol string) (bool,
 	return !os.IsNotExist(err), nil
 }
 
+// CreateNetwork creates a bridge by the Network
+func (q QemuProvider) CreateNetwork(ctx context.Context, net *Network) error {
+	c := cmd.CommandContext(ctx, "ip", "link", "add", net.Name, "type", "bridge")
+	log.Info("Creating network", map[string]interface{}{"name": net.Name})
+	return c.Run()
+}
+
+// DestroyNetwork destroies a bridge by the name
+func (q QemuProvider) DestroyNetwork(ctx context.Context, name string) error {
+	c := cmd.CommandContext(ctx, "ip", "link", "delete", name, "type", "bridge")
+	log.Info("Destroying network", map[string]interface{}{"name": name})
+	return c.Run()
+}
+
 // CreateVolume creates the named by node and vol
 func (q QemuProvider) CreateVolume(ctx context.Context, node string, vol *VolumeSpec) error {
 	p := q.volumePath(node, vol.Name)

--- a/qemu.go
+++ b/qemu.go
@@ -51,6 +51,10 @@ func (q QemuProvider) CreateNetwork(ctx context.Context, net *Network) error {
 	if err != nil {
 		return err
 	}
+	err = cmd.CommandContext(ctx, "ip", "link", "set", net.Name, "up").Run()
+	if err != nil {
+		return err
+	}
 	for _, addr := range net.Spec.Addresses {
 		err := cmd.CommandContext(ctx, "ip", "addr", "add", addr, "dev", net.Name).Run()
 		if err != nil {

--- a/qemu.go
+++ b/qemu.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"os"
 	"path"
-	"time"
 
 	"github.com/cybozu-go/cmd"
 	"github.com/cybozu-go/log"
@@ -110,17 +109,13 @@ func (q QemuProvider) StartNode(ctx context.Context, n *Node) error {
 
 	for _, br := range n.Spec.Interfaces {
 		tap := n.Name + "_" + br
-		func() {
-			ctx2, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-			defer cancel()
-			err := deleteTap(ctx2, tap)
-			if err != nil {
-				log.Error("Failed to delete a TAP", map[string]interface{}{
-					"name":  tap,
-					"error": err,
-				})
-			}
-		}()
+		err := deleteTap(context.Background(), tap)
+		if err != nil {
+			log.Error("Failed to delete a TAP", map[string]interface{}{
+				"name":  tap,
+				"error": err,
+			})
+		}
 	}
 	return nil
 }

--- a/resource.go
+++ b/resource.go
@@ -56,6 +56,8 @@ type Cluster struct {
 
 // Append appends the other cluster into the receiver
 func (c *Cluster) Append(other *Cluster) *Cluster {
+	c.Networks = append(c.Networks, other.Networks...)
 	c.Nodes = append(c.Nodes, other.Nodes...)
+	c.NodeSets = append(c.NodeSets, other.NodeSets...)
 	return c
 }

--- a/resource.go
+++ b/resource.go
@@ -14,8 +14,16 @@ const (
 	RecreateNever
 )
 
+// NetworkSpec represents a network specification
+type NetworkSpec struct {
+	Addresses []string
+}
+
 // Network represents a network configuration
-type Network struct{}
+type Network struct {
+	Name string
+	Spec NetworkSpec
+}
 
 // VolumeSpec represents a volume specification
 type VolumeSpec struct {

--- a/server.go
+++ b/server.go
@@ -2,7 +2,6 @@ package placemat
 
 import (
 	"context"
-	"time"
 
 	"github.com/cybozu-go/cmd"
 	"github.com/cybozu-go/log"
@@ -67,10 +66,8 @@ func handleDestroyNetwork(env *cmd.Environment, provider Provider, networks []*N
 	env.Go(func(ctx context.Context) error {
 		<-ctx.Done()
 
-		ctx2, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-		defer cancel()
 		for _, name := range names {
-			err := provider.DestroyNetwork(ctx2, name)
+			err := provider.DestroyNetwork(context.Background(), name)
 			if err != nil {
 				log.Info("Failed to destroy networks", map[string]interface{}{
 					"name":  name,

--- a/server.go
+++ b/server.go
@@ -62,11 +62,11 @@ func startNodes(env *cmd.Environment, provider Provider, cluster *Cluster) {
 
 // Run runs VMs described in cluster by provider
 func Run(ctx context.Context, provider Provider, cluster *Cluster) error {
-	err := createNodeVolumes(ctx, provider, cluster)
+	err := createNetworks(ctx, provider, cluster.Networks)
 	if err != nil {
 		return err
 	}
-	err = createNetworks(ctx, provider, cluster.Networks)
+	err = createNodeVolumes(ctx, provider, cluster)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION

Network resource is supported.  Define Network resources as following:

```yaml
# cluster.yml
kind: Network
name: net1
spec:
  addresses:
    - 172.16.0.1/24
---
kind: Node
name: boot-0
spec:
  volumes:
    - name: system
      size: 10G
      recreatePolicy: Never
  interfaces:
    - net1
```

Placemat creates bridges (virtual L2 bridges) corresponding to Network resources.  The `addresses` parameter contains IP addresses which host assigns to the bridge.

You can observe a bridge named `net1`, and TAP named `boot-0_net1` which VM connets.  The VM can connecto to host's bridge with IP addresses `172.16.0.0/24`.

```console
$ ip link
1126: net1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP mode DEFAULT group default qlen 1000
    link/ether ea:43:bc:a8:bf:51 brd ff:ff:ff:ff:ff:ff
1127: boot-0_net1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast master net1 state UP mode DEFAULT group default qlen 1000
    link/ether ea:43:bc:a8:bf:51 brd ff:ff:ff:ff:ff:ff
```
