### PR TITLE
Create volume from url

### DIFF
--- a/cmd/placemat/yaml.go
+++ b/cmd/placemat/yaml.go
@@ -131,6 +131,8 @@ func constructNodeSpec(ns nodeSpec) (placemat.NodeSpec, error) {
 			return res, errors.New("invalid volume type: must specify only one of 'size' or 'source' or 'cloud-config'")
 		}
 	}
+	res.Resources.Cpu = ns.Resources.Cpu
+	res.Resources.Memory = ns.Resources.Memory
 
 	return res, nil
 }

--- a/cmd/placemat/yaml.go
+++ b/cmd/placemat/yaml.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"errors"
+	"fmt"
 	"io"
 
 	"github.com/cybozu-go/placemat"
@@ -26,7 +27,7 @@ type nodeSpec struct {
 		RecreatePolicy string `yaml:"recreatePolicy"`
 	} `yaml:"volumes"`
 	Resources struct {
-		Cpu    string `yaml:"cpu"`
+		CPU    string `yaml:"cpu"`
 		Memory string `yaml:"memory"`
 	} `yaml:"resources"`
 }
@@ -115,7 +116,7 @@ func constructNodeSpec(ns nodeSpec) (placemat.NodeSpec, error) {
 		var ok bool
 		dst.RecreatePolicy, ok = recreatePolicyConfig[v.RecreatePolicy]
 		if !ok {
-			return placemat.NodeSpec{}, errors.New("Invalid RecreatePolicy: " + v.RecreatePolicy)
+			return placemat.NodeSpec{}, fmt.Errorf("invalid RecreatePolicy: %s" + v.RecreatePolicy)
 		}
 		count := 0
 		if v.Size != "" {
@@ -131,7 +132,7 @@ func constructNodeSpec(ns nodeSpec) (placemat.NodeSpec, error) {
 			return res, errors.New("invalid volume type: must specify only one of 'size' or 'source' or 'cloud-config'")
 		}
 	}
-	res.Resources.Cpu = ns.Resources.Cpu
+	res.Resources.CPU = ns.Resources.CPU
 	res.Resources.Memory = ns.Resources.Memory
 
 	return res, nil

--- a/cmd/placemat/yaml_test.go
+++ b/cmd/placemat/yaml_test.go
@@ -94,9 +94,9 @@ spec:
 						{Name: "data", Size: "20GB", RecreatePolicy: placemat.RecreateIfNotPresent},
 					},
 					Resources: struct {
-						Cpu    string
+						CPU    string
 						Memory string
-					}{Cpu: "4", Memory: "8G"},
+					}{CPU: "4", Memory: "8G"},
 				},
 			},
 		},

--- a/cmd/placemat/yaml_test.go
+++ b/cmd/placemat/yaml_test.go
@@ -79,6 +79,9 @@ spec:
         user-data: user-data.yml
     - name: data
       size: 20GB
+  resources:
+    cpu: 4
+    memory: 8G
 `,
 
 			expected: placemat.Node{
@@ -90,6 +93,10 @@ spec:
 						{Name: "seed", CloudConfig: struct{ UserData string }{UserData: "user-data.yml"}, RecreatePolicy: placemat.RecreateAlways},
 						{Name: "data", Size: "20GB", RecreatePolicy: placemat.RecreateIfNotPresent},
 					},
+					Resources: struct {
+						Cpu    string
+						Memory string
+					}{Cpu: "4", Memory: "8G"},
 				},
 			},
 		},

--- a/qemu.go
+++ b/qemu.go
@@ -178,6 +178,12 @@ func (q QemuProvider) StartNode(ctx context.Context, n *Node) error {
 		p := q.volumePath(n.Name, v.Name)
 		params = append(params, "-drive", "if=virtio,cache=none,aio=native,file="+p)
 	}
+	if n.Spec.Resources.Cpu != "" {
+		params = append(params, "-smp", n.Spec.Resources.Cpu)
+	}
+	if n.Spec.Resources.Memory != "" {
+		params = append(params, "-m", n.Spec.Resources.Memory)
+	}
 	err := cmd.CommandContext(ctx, "qemu-system-x86_64", params...).Run()
 	if err != nil {
 		log.Error("QEMU exited with an error", map[string]interface{}{

--- a/qemu.go
+++ b/qemu.go
@@ -178,8 +178,8 @@ func (q QemuProvider) StartNode(ctx context.Context, n *Node) error {
 		p := q.volumePath(n.Name, v.Name)
 		params = append(params, "-drive", "if=virtio,cache=none,aio=native,file="+p)
 	}
-	if n.Spec.Resources.Cpu != "" {
-		params = append(params, "-smp", n.Spec.Resources.Cpu)
+	if n.Spec.Resources.CPU != "" {
+		params = append(params, "-smp", n.Spec.Resources.CPU)
 	}
 	if n.Spec.Resources.Memory != "" {
 		params = append(params, "-m", n.Spec.Resources.Memory)

--- a/resource.go
+++ b/resource.go
@@ -41,7 +41,7 @@ type VolumeSpec struct {
 
 // ResourceSpec represents a resource specification
 type ResourceSpec struct {
-	Cpu    string
+	CPU    string
 	Memory string
 }
 

--- a/resource.go
+++ b/resource.go
@@ -39,10 +39,17 @@ type VolumeSpec struct {
 	RecreatePolicy VolumeRecreatePolicy
 }
 
+// ResourceSpec represents a resource specification
+type ResourceSpec struct {
+	Cpu    string
+	Memory string
+}
+
 // NodeSpec represents a node specification
 type NodeSpec struct {
 	Interfaces []string
 	Volumes    []*VolumeSpec
+	Resources  ResourceSpec
 }
 
 // Node represents a node configuration

--- a/resource.go
+++ b/resource.go
@@ -25,10 +25,17 @@ type Network struct {
 	Spec NetworkSpec
 }
 
+// CloudConfigSpec represents a cloud-config configuration
+type CloudConfigSpec struct {
+	UserData string
+}
+
 // VolumeSpec represents a volume specification
 type VolumeSpec struct {
 	Name           string
 	Size           string
+	Source         string
+	CloudConfig    CloudConfigSpec
 	RecreatePolicy VolumeRecreatePolicy
 }
 


### PR DESCRIPTION
This PR adds two volume's fields `source` and `cloud-config`, and adds `resources` field.

One of `size`, `source` or `cloud-config` can be specified as the volume type.
* `size` : create an empty volume image using `qemu-img`
* `source`: use the image downloaded from the specified URL
* `cloud-config`: create  a volume image using `cloud-localds` with the specified config file

The `resources` field specifies the resource to be assigned to the VM.
* `cpu`: number of cpu cores
* `memory`: amount of memory

In the example below, the node has three type volumes, 4cpu and 8G memory.

```yaml
kind: Node
name: boot-1
spec:
  volumes:
    - name: data
      size: 10G
    - name: ubuntu
      source: https://cloud-images.ubuntu.com/releases/16.04/release/ubuntu-16.04-server-cloudimg-amd64-disk1.img
      recreatePolicy: IfNotPresent
    - name: seed
      cloud-config:
        user-data: conf.yml
  resources:
    cpu: 4
    memory: 8G
```

