### PR TITLE
Enable to set ip addresses by ubuntu cloud image

### DIFF
--- a/cmd/placemat/main.go
+++ b/cmd/placemat/main.go
@@ -4,7 +4,10 @@ import (
 	"bufio"
 	"context"
 	"flag"
+	"math/rand"
 	"os"
+
+	"time"
 
 	"github.com/cybozu-go/cmd"
 	"github.com/cybozu-go/log"
@@ -51,6 +54,8 @@ func run(args []string) error {
 }
 
 func main() {
+	rand.Seed(time.Now().UnixNano())
+
 	flag.Parse()
 	cmd.LogConfig{}.Apply()
 

--- a/cmd/placemat/main.go
+++ b/cmd/placemat/main.go
@@ -6,7 +6,6 @@ import (
 	"flag"
 	"math/rand"
 	"os"
-
 	"time"
 
 	"github.com/cybozu-go/cmd"

--- a/cmd/placemat/yaml.go
+++ b/cmd/placemat/yaml.go
@@ -22,7 +22,8 @@ type nodeSpec struct {
 		Size        string `yaml:"size"`
 		Source      string `yaml:"source"`
 		CloudConfig struct {
-			UserData string `yaml:"user-data"`
+			UserData      string `yaml:"user-data"`
+			NetworkConfig string `yaml:"network-config"`
 		} `yaml:"cloud-config"`
 		RecreatePolicy string `yaml:"recreatePolicy"`
 	} `yaml:"volumes"`
@@ -113,6 +114,7 @@ func constructNodeSpec(ns nodeSpec) (placemat.NodeSpec, error) {
 		dst.Size = v.Size
 		dst.Source = v.Source
 		dst.CloudConfig.UserData = v.CloudConfig.UserData
+		dst.CloudConfig.NetworkConfig = v.CloudConfig.NetworkConfig
 		var ok bool
 		dst.RecreatePolicy, ok = recreatePolicyConfig[v.RecreatePolicy]
 		if !ok {

--- a/cmd/placemat/yaml_test.go
+++ b/cmd/placemat/yaml_test.go
@@ -76,6 +76,7 @@ spec:
     - name: seed
       recreatePolicy: Always
       cloud-config: 
+        network-config: network.yml
         user-data: user-data.yml
     - name: data
       size: 20GB
@@ -90,7 +91,14 @@ spec:
 					Interfaces: []string{"br0", "br1"},
 					Volumes: []*placemat.VolumeSpec{
 						{Name: "ubuntu", Source: "https://cloud-images.ubuntu.com/releases/16.04/release/ubuntu-16.04-server-cloudimg-amd64-disk1.img", RecreatePolicy: placemat.RecreateIfNotPresent},
-						{Name: "seed", CloudConfig: struct{ UserData string }{UserData: "user-data.yml"}, RecreatePolicy: placemat.RecreateAlways},
+						{Name: "seed", CloudConfig: struct {
+							NetworkConfig string
+							UserData      string
+						}{
+							NetworkConfig: "network.yml",
+							UserData:      "user-data.yml",
+						},
+							RecreatePolicy: placemat.RecreateAlways},
 						{Name: "data", Size: "20GB", RecreatePolicy: placemat.RecreateIfNotPresent},
 					},
 					Resources: struct {
@@ -144,6 +152,7 @@ spec:
     - name: mixed
       source: https://cloud-images.ubuntu.com/releases/16.04/release/ubuntu-16.04-server-cloudimg-amd64-disk1.img
       cloud-config: 
+        network-config: network.yml
         user-data: user-data.yml
       size: 20GB
       recreatePolicy: IfNotPresent

--- a/qemu.go
+++ b/qemu.go
@@ -13,6 +13,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"math/rand"
+
 	"github.com/cybozu-go/cmd"
 	"github.com/cybozu-go/log"
 )
@@ -183,7 +185,8 @@ func (q QemuProvider) StartNode(ctx context.Context, n *Node) error {
 		}
 
 		params = append(params, "-netdev", netdev)
-		params = append(params, "-device", "virtio-net-pci,netdev="+br+",romfile=")
+		params = append(params, "-device",
+			fmt.Sprintf("virtio-net-pci,netdev=%s,romfile=,mac=%s", br, generateRandomMACForKVM()))
 	}
 	for _, v := range n.Spec.Volumes {
 		p := q.volumePath(n.Name, v.Name)
@@ -213,4 +216,11 @@ func (q QemuProvider) StartNode(ctx context.Context, n *Node) error {
 		}
 	}
 	return nil
+}
+
+func generateRandomMACForKVM() string {
+	prefix := "52:54:00"
+	bytes := make([]byte, 3)
+	rand.Read(bytes)
+	return fmt.Sprintf("%s:%02x:%02x:%02x", prefix, bytes[0], bytes[1], bytes[2])
 }

--- a/qemu.go
+++ b/qemu.go
@@ -7,13 +7,12 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"math/rand"
 	"net/http"
 	"os"
 	"path"
 	"path/filepath"
 	"strings"
-
-	"math/rand"
 
 	"github.com/cybozu-go/cmd"
 	"github.com/cybozu-go/log"
@@ -223,8 +222,8 @@ func (q QemuProvider) StartNode(ctx context.Context, n *Node) error {
 }
 
 func generateRandomMACForKVM() string {
-	prefix := "52:54:00"
+	vendorPrefix := "52:54:00" // QEMU's vendor prefix
 	bytes := make([]byte, 3)
 	rand.Read(bytes)
-	return fmt.Sprintf("%s:%02x:%02x:%02x", prefix, bytes[0], bytes[1], bytes[2])
+	return fmt.Sprintf("%s:%02x:%02x:%02x", vendorPrefix, bytes[0], bytes[1], bytes[2])
 }

--- a/qemu_test.go
+++ b/qemu_test.go
@@ -3,6 +3,7 @@ package placemat
 import (
 	"context"
 	"io/ioutil"
+	"net"
 	"os"
 	"testing"
 )
@@ -69,6 +70,10 @@ func TestGenerateRandomMacForKVM(t *testing.T) {
 	}
 	if sut == generateRandomMACForKVM() {
 		t.Fatal("it should generate unique address")
+	}
+	_, err := net.ParseMAC(sut)
+	if err != nil {
+		t.Fatal("invalid MAC address", err)
 	}
 
 }

--- a/qemu_test.go
+++ b/qemu_test.go
@@ -62,6 +62,17 @@ func TestCreateVolume(t *testing.T) {
 	}
 }
 
+func TestGenerateRandomMacForKVM(t *testing.T) {
+	sut := generateRandomMACForKVM()
+	if len(sut) != 17 {
+		t.Fatal("length of MAC address string is not 17")
+	}
+	if sut == generateRandomMACForKVM() {
+		t.Fatal("it should generate unique address")
+	}
+
+}
+
 func TestStartNode(t *testing.T) {
 	// TODO add tests
 }

--- a/resource.go
+++ b/resource.go
@@ -27,7 +27,8 @@ type Network struct {
 
 // CloudConfigSpec represents a cloud-config configuration
 type CloudConfigSpec struct {
-	UserData string
+	NetworkConfig string
+	UserData      string
 }
 
 // VolumeSpec represents a volume specification


### PR DESCRIPTION
- To set IP address using Ubuntu cloud image, enable to set the `--network-config` option of `cloud-localds`.
- give a unique MAC address each NICs.