### PR TITLE
Enable UEFI and persist NVRAM

### DIFF
--- a/cmd/placemat/yaml.go
+++ b/cmd/placemat/yaml.go
@@ -31,6 +31,7 @@ type nodeSpec struct {
 		CPU    string `yaml:"cpu"`
 		Memory string `yaml:"memory"`
 	} `yaml:"resources"`
+	BIOS string `yaml:"bios"`
 }
 
 type nodeConfig struct {
@@ -58,6 +59,12 @@ var recreatePolicyConfig = map[string]placemat.VolumeRecreatePolicy{
 	"IfNotPresent": placemat.RecreateIfNotPresent,
 	"Always":       placemat.RecreateAlways,
 	"Never":        placemat.RecreateNever,
+}
+
+var biosConfig = map[string]placemat.BIOSMode{
+	"":       placemat.LegacyBIOS,
+	"legacy": placemat.LegacyBIOS,
+	"uefi":   placemat.UEFI,
 }
 
 func unmarshalNode(data []byte) (*placemat.Node, error) {
@@ -136,6 +143,7 @@ func constructNodeSpec(ns nodeSpec) (placemat.NodeSpec, error) {
 	}
 	res.Resources.CPU = ns.Resources.CPU
 	res.Resources.Memory = ns.Resources.Memory
+	res.BIOS = biosConfig[ns.BIOS]
 
 	return res, nil
 }

--- a/cmd/placemat/yaml.go
+++ b/cmd/placemat/yaml.go
@@ -108,6 +108,7 @@ func unmarshalNodeSet(data []byte) (*placemat.NodeSet, error) {
 
 func constructNodeSpec(ns nodeSpec) (placemat.NodeSpec, error) {
 	var res placemat.NodeSpec
+	var ok bool
 	res.Interfaces = ns.Interfaces
 	if ns.Interfaces == nil {
 		res.Interfaces = []string{}
@@ -122,10 +123,9 @@ func constructNodeSpec(ns nodeSpec) (placemat.NodeSpec, error) {
 		dst.Source = v.Source
 		dst.CloudConfig.UserData = v.CloudConfig.UserData
 		dst.CloudConfig.NetworkConfig = v.CloudConfig.NetworkConfig
-		var ok bool
 		dst.RecreatePolicy, ok = recreatePolicyConfig[v.RecreatePolicy]
 		if !ok {
-			return placemat.NodeSpec{}, fmt.Errorf("invalid RecreatePolicy: %s" + v.RecreatePolicy)
+			return placemat.NodeSpec{}, fmt.Errorf("invalid RecreatePolicy: " + v.RecreatePolicy)
 		}
 		count := 0
 		if v.Size != "" {
@@ -143,7 +143,10 @@ func constructNodeSpec(ns nodeSpec) (placemat.NodeSpec, error) {
 	}
 	res.Resources.CPU = ns.Resources.CPU
 	res.Resources.Memory = ns.Resources.Memory
-	res.BIOS = biosConfig[ns.BIOS]
+	res.BIOS, ok = biosConfig[ns.BIOS]
+	if !ok {
+		return placemat.NodeSpec{}, fmt.Errorf("invalid BIOS: " + ns.BIOS)
+	}
 
 	return res, nil
 }

--- a/cmd/placemat/yaml_test.go
+++ b/cmd/placemat/yaml_test.go
@@ -83,6 +83,7 @@ spec:
   resources:
     cpu: 4
     memory: 8G
+  bios: legacy
 `,
 
 			expected: placemat.Node{
@@ -105,6 +106,7 @@ spec:
 						CPU    string
 						Memory string
 					}{CPU: "4", Memory: "8G"},
+					BIOS: placemat.LegacyBIOS,
 				},
 			},
 		},

--- a/cmd/placemat/yaml_test.go
+++ b/cmd/placemat/yaml_test.go
@@ -148,6 +148,26 @@ spec:
 		{
 			source: `
 kind: Node
+name: node1
+spec:
+  bios: None
+`,
+			expected: "invalid BIOS: None",
+		},
+		{
+			source: `
+kind: Node
+name: node1
+spec:
+  volumes:
+    - name: vol
+      recreatePolicy: Sometime
+`,
+			expected: "invalid RecreatePolicy: Sometime",
+		},
+		{
+			source: `
+kind: Node
 name: node4
 spec:
   volumes:

--- a/qemu.go
+++ b/qemu.go
@@ -18,6 +18,11 @@ import (
 	"github.com/cybozu-go/log"
 )
 
+const (
+	defaultOVMFCodePath = "/usr/share/OVMF/OVMF_CODE.fd"
+	defaultOVMFVarsPath = "/usr/share/OVMF/OVMF_VARS.fd"
+)
+
 var vhostNetSupported bool
 
 func init() {
@@ -67,6 +72,10 @@ func deleteTap(ctx context.Context, tap string) error {
 
 func (q QemuProvider) volumePath(host, name string) string {
 	return path.Join(q.BaseDir, host+"_"+name+".img")
+}
+
+func (q QemuProvider) nvramPath(host string) string {
+	return path.Join(q.BaseDir, host+"_nvram.fd")
 }
 
 // VolumeExists checks if the volume exists
@@ -172,6 +181,14 @@ func (q QemuProvider) CreateVolume(ctx context.Context, node string, vol *Volume
 	return errors.New("invalid volume type")
 }
 
+func createNVRAM(ctx context.Context, p string) error {
+	_, err := os.Stat(p)
+	if !os.IsNotExist(err) {
+		return nil
+	}
+	return cmd.CommandContext(ctx, "cp", defaultOVMFVarsPath, p).Run()
+}
+
 // StartNode starts a QEMU vm
 func (q QemuProvider) StartNode(ctx context.Context, n *Node) error {
 	params := []string{"-enable-kvm"}
@@ -200,6 +217,18 @@ func (q QemuProvider) StartNode(ctx context.Context, n *Node) error {
 	}
 	if n.Spec.Resources.Memory != "" {
 		params = append(params, "-m", n.Spec.Resources.Memory)
+	}
+	if n.Spec.BIOS == UEFI {
+		p := q.nvramPath(n.Name)
+		err := createNVRAM(ctx, p)
+		if err != nil {
+			log.Error("Failed to create nvram", map[string]interface{}{
+				"error": err,
+			})
+			return err
+		}
+		params = append(params, "-drive", "if=pflash,file="+defaultOVMFCodePath+",format=raw,readonly")
+		params = append(params, "-drive", "if=pflash,file="+p+",format=raw")
 	}
 	err := cmd.CommandContext(ctx, "qemu-system-x86_64", params...).Run()
 	if err != nil {

--- a/resource.go
+++ b/resource.go
@@ -18,7 +18,7 @@ const (
 type BIOSMode int
 
 // BIOS mode, For LegacyBIOS, QEMU launch a vm with no options about bios. For
-// UEIF, QEMU launch a vm with OVMF.
+// UEFI, QEMU launch a vm with OVMF.
 const (
 	LegacyBIOS BIOSMode = iota
 	UEFI

--- a/resource.go
+++ b/resource.go
@@ -17,7 +17,8 @@ const (
 // BIOSMode represents a bios mode
 type BIOSMode int
 
-// BIOS mode, BIOSLegacy is legacy bios mode (default), and BIOSUEIF uses OVMF.
+// BIOS mode, For LegacyBIOS, QEMU launch a vm with no options about bios. For
+// UEIF, QEMU launch a vm with OVMF.
 const (
 	LegacyBIOS = iota
 	UEFI

--- a/resource.go
+++ b/resource.go
@@ -14,6 +14,15 @@ const (
 	RecreateNever
 )
 
+// BIOSMode represents a bios mode
+type BIOSMode int
+
+// BIOS mode, BIOSLegacy is legacy bios mode (default), and BIOSUEIF uses OVMF.
+const (
+	LegacyBIOS = iota
+	UEFI
+)
+
 // NetworkSpec represents a network specification
 type NetworkSpec struct {
 	Addresses []string
@@ -51,6 +60,7 @@ type NodeSpec struct {
 	Interfaces []string
 	Volumes    []*VolumeSpec
 	Resources  ResourceSpec
+	BIOS       BIOSMode
 }
 
 // Node represents a node configuration

--- a/resource.go
+++ b/resource.go
@@ -20,7 +20,7 @@ type BIOSMode int
 // BIOS mode, For LegacyBIOS, QEMU launch a vm with no options about bios. For
 // UEIF, QEMU launch a vm with OVMF.
 const (
-	LegacyBIOS = iota
+	LegacyBIOS BIOSMode = iota
 	UEFI
 )
 


### PR DESCRIPTION
New property `bios` is available for a Node resource:

```yaml
kind: Node
name: boot-0
spec:
  bios: uefi  # legacy or ueif
```

If `bios: legacy` is set or `bios` property is not set, QEMU launch a VM with legacy BIOS.  If `bios: ueif` is set, QEMU launch a VM with UEFI.  UEFI is loaded by OVMF, and data in NVRAM is persisted into the disk on the host machine.