### PR TITLE
Use C-q prefix for placemat-connect

### DIFF
--- a/cmd/placemat-connect/main.go
+++ b/cmd/placemat-connect/main.go
@@ -52,7 +52,7 @@ func run(args []string) error {
 	cmd.Go(func(ctx context.Context) error {
 		time.Sleep(1 * time.Second)
 
-		cmd := exec.CommandContext(ctx, "picocom", "-e", "[", pty)
+		cmd := exec.CommandContext(ctx, "picocom", "-e", "q", pty)
 		cmd.Stdin = os.Stdin
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr


### PR DESCRIPTION
C-[ is used in escape cahracters. picocom failed to send escape keys to
serial console.  It has been changed to C-q.