### PR TITLE
Support SMBIOS property for a Node resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,10 @@ spec:
   resources:
     cpu: 2
     memory: 4G
+  smbios:
+    manufacturer: cybozu
+    product: mk2
+    serial: 1234abcd
   bios: legacy
 ```
 
@@ -161,6 +165,7 @@ The properties in the `spec` are the following:
   - `cloud-config`:  Generate a disk for cloud-init to utilize [nocloud](http://cloudinit.readthedocs.io/en/latest/topics/datasources/nocloud.html), which allows the user to provide user-data and meta-data to the instance without running a network service.  `cloud-config` has two properties, `user-data` and `network-config`.
   - `source`:  Create a disk from URL via HTTP.
 - `resources`:  `cpu` and `memory` resources to allocate to the VM.
+- `smbios`: System Management BIOS (SMBIOS) values for `manufacturer`, `product`, and `serial`.  If `serial` is not set, a hash value of the node's name is used.
 - `bios`: BIOS mode of the VM.  If `uefi` is specified, the VM loads OVMF as BIOS.
 
 Placemat launch a `qemu-system-x86_64` process by a Node resource.  If `size`

--- a/cmd/placemat/yaml.go
+++ b/cmd/placemat/yaml.go
@@ -31,7 +31,12 @@ type nodeSpec struct {
 		CPU    string `yaml:"cpu"`
 		Memory string `yaml:"memory"`
 	} `yaml:"resources"`
-	BIOS string `yaml:"bios"`
+	BIOS   string `yaml:"bios"`
+	SMBIOS struct {
+		Manufacturer string `yaml:"manufacturer"`
+		ProductName  string `yaml:"product"`
+		SerialNumber string `yaml:"serial"`
+	} `yaml:"smbios"`
 }
 
 type nodeConfig struct {
@@ -147,6 +152,9 @@ func constructNodeSpec(ns nodeSpec) (placemat.NodeSpec, error) {
 	if !ok {
 		return placemat.NodeSpec{}, fmt.Errorf("invalid BIOS: " + ns.BIOS)
 	}
+	res.SMBIOS.Manufacturer = ns.SMBIOS.Manufacturer
+	res.SMBIOS.Product = ns.SMBIOS.ProductName
+	res.SMBIOS.Serial = ns.SMBIOS.SerialNumber
 
 	return res, nil
 }

--- a/cmd/placemat/yaml_test.go
+++ b/cmd/placemat/yaml_test.go
@@ -84,6 +84,10 @@ spec:
     cpu: 4
     memory: 8G
   bios: legacy
+  smbios:
+    manufacturer: QEMU
+    product: Mk2
+    serial: 1234abcd
 `,
 
 			expected: placemat.Node{
@@ -102,11 +106,9 @@ spec:
 							RecreatePolicy: placemat.RecreateAlways},
 						{Name: "data", Size: "20GB", RecreatePolicy: placemat.RecreateIfNotPresent},
 					},
-					Resources: struct {
-						CPU    string
-						Memory string
-					}{CPU: "4", Memory: "8G"},
-					BIOS: placemat.LegacyBIOS,
+					Resources: placemat.ResourceSpec{CPU: "4", Memory: "8G"},
+					BIOS:      placemat.LegacyBIOS,
+					SMBIOS:    placemat.SMBIOSSpec{Manufacturer: "QEMU", Product: "Mk2", Serial: "1234abcd"},
 				},
 			},
 		},

--- a/qemu.go
+++ b/qemu.go
@@ -3,6 +3,7 @@ package placemat
 import (
 	"bufio"
 	"context"
+	"crypto/sha1"
 	"errors"
 	"fmt"
 	"io"
@@ -349,6 +350,21 @@ func (q QemuProvider) StartNode(ctx context.Context, n *Node) error {
 		params = append(params, "-drive", "if=pflash,file="+defaultOVMFCodePath+",format=raw,readonly")
 		params = append(params, "-drive", "if=pflash,file="+p+",format=raw")
 	}
+
+	smbios := "type=1"
+	if n.Spec.SMBIOS.Manufacturer != "" {
+		smbios += ",manufacturer=" + n.Spec.SMBIOS.Manufacturer
+	}
+	if n.Spec.SMBIOS.Product != "" {
+		smbios += ",product=" + n.Spec.SMBIOS.Product
+	}
+	if n.Spec.SMBIOS.Serial != "" {
+		smbios += ",serial=" + n.Spec.SMBIOS.Serial
+	} else {
+		smbios += ",serial=" + fmt.Sprintf("%x", sha1.Sum([]byte(n.Name)))
+	}
+	params = append(params, "-smbios", smbios)
+
 	log.Info("Starting VM", map[string]interface{}{"name": n.Name})
 	err := cmd.CommandContext(ctx, "qemu-system-x86_64", params...).Run()
 	if err != nil {

--- a/resource.go
+++ b/resource.go
@@ -56,12 +56,20 @@ type ResourceSpec struct {
 	Memory string
 }
 
+// SMBIOSSpec represents a manufacturer name, product name, and serial number in smbios
+type SMBIOSSpec struct {
+	Manufacturer string
+	Product      string
+	Serial       string
+}
+
 // NodeSpec represents a node specification
 type NodeSpec struct {
 	Interfaces []string
 	Volumes    []*VolumeSpec
 	Resources  ResourceSpec
 	BIOS       BIOSMode
+	SMBIOS     SMBIOSSpec
 }
 
 // Node represents a node configuration


### PR DESCRIPTION
System Management BIOS (SMBIOS) properties are supported for a Node resource as the following:

```yaml
kind: Node
name: my-node
spec:
  smbios:
    manufacturer: cybozu
    product: mk2
    serial: 1234abcd
```

It can observe by a `dmidecode` command from Linux userspace:

```console
$ sudo dmidecode -s system-manufacturer
cybozu
$ sudo dmidecode -s system-product-name
mk2
$ sudo dmidecode -s system-serial-number
1234abcd
```