### PR TITLE
Add support for Ignition.

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -75,6 +75,7 @@ spec:
     - name: data
       size: 10GB
       recreatePolicy: Never
+  ignition: my-node.ign
   resources:
     cpu: 2
     memory: 4G
@@ -92,6 +93,7 @@ The properties in the `spec` are the following:
   - `size`:  Create a new disk by disk `size`.
   - `cloud-config`:  Generate a disk for cloud-init to utilize [nocloud](http://cloudinit.readthedocs.io/en/latest/topics/datasources/nocloud.html), which allows the user to provide user-data and meta-data to the instance without running a network service.  `cloud-config` has two properties, `user-data` and `network-config`.
   - `source`:  Name of an image resource.
+- `ignition`: [Ignition file](https://coreos.com/ignition/docs/latest/configuration-v2_1.html).
 - `resources`:  `cpu` and `memory` resources to allocate to the VM.
 - `smbios`: System Management BIOS (SMBIOS) values for `manufacturer`, `product`, and `serial`.  If `serial` is not set, a hash value of the node's name is used.
 - `bios`: BIOS mode of the VM.  If `uefi` is specified, the VM loads OVMF as BIOS.

--- a/cmd/placemat/yaml.go
+++ b/cmd/placemat/yaml.go
@@ -28,7 +28,8 @@ type nodeSpec struct {
 		} `yaml:"cloud-config"`
 		RecreatePolicy string `yaml:"recreatePolicy"`
 	} `yaml:"volumes"`
-	Resources struct {
+	IgnitionFile string `yaml:"ignition"`
+	Resources    struct {
 		CPU    string `yaml:"cpu"`
 		Memory string `yaml:"memory"`
 	} `yaml:"resources"`
@@ -158,6 +159,7 @@ func constructNodeSpec(ns nodeSpec) (placemat.NodeSpec, error) {
 			return res, errors.New("invalid volume type: must specify only one of 'size' or 'source' or 'cloud-config'")
 		}
 	}
+	res.IgnitionFile = ns.IgnitionFile
 	res.Resources.CPU = ns.Resources.CPU
 	res.Resources.Memory = ns.Resources.Memory
 	res.BIOS, ok = biosConfig[ns.BIOS]

--- a/qemu.go
+++ b/qemu.go
@@ -278,6 +278,11 @@ func nodeSerial(name string) string {
 func (q QemuProvider) qemuParams(n *Node) []string {
 	params := []string{"-enable-kvm"}
 
+	if n.Spec.IgnitionFile != "" {
+		params = append(params, "-fw_cfg")
+		params = append(params, "opt/com.coreos/config,file="+n.Spec.IgnitionFile)
+	}
+
 	for _, br := range n.Spec.Interfaces {
 		tap := n.Name + "_" + br
 		netdev := "tap,id=" + br + ",ifname=" + tap + ",script=no,downscript=no"

--- a/resource.go
+++ b/resource.go
@@ -110,11 +110,12 @@ type SMBIOSSpec struct {
 
 // NodeSpec represents a node specification
 type NodeSpec struct {
-	Interfaces []string
-	Volumes    []*VolumeSpec
-	Resources  ResourceSpec
-	BIOS       BIOSMode
-	SMBIOS     SMBIOSSpec
+	Interfaces   []string
+	Volumes      []*VolumeSpec
+	IgnitionFile string
+	Resources    ResourceSpec
+	BIOS         BIOSMode
+	SMBIOS       SMBIOSSpec
 }
 
 // Node represents a node configuration


### PR DESCRIPTION
Using QEMU -fw_cfg with opt/com.coreos/config key,
Ignition file can be passed to the CoreOS image.