### PR TITLE
[placemat] chdir to the directory of YAML file

### DIFF
--- a/cmd/placemat/main.go
+++ b/cmd/placemat/main.go
@@ -7,6 +7,7 @@ import (
 	"flag"
 	"math/rand"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/cybozu-go/cmd"
@@ -52,12 +53,28 @@ func run(yamls []string) error {
 		return errors.New("no YAML files specified")
 	}
 
+	// make all YAML paths absolute
+	for i, p := range yamls {
+		abs, err := filepath.Abs(p)
+		if err != nil {
+			return err
+		}
+		yamls[i] = abs
+	}
+
+	err := os.Chdir(filepath.Dir(yamls[0]))
+	if err != nil {
+		log.Warn("cannot chdir to YAML directory", map[string]interface{}{
+			log.FnError: err.Error(),
+		})
+	}
+
 	qemu := &placemat.QemuProvider{
 		NoGraphic: *flgNoGraphic,
 		RunDir:    *flgRunDir,
 	}
 
-	err := qemu.SetupDataDir(os.ExpandEnv(*flgDataDir))
+	err = qemu.SetupDataDir(os.ExpandEnv(*flgDataDir))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
In YAML, file paths are often written as relative from the YAML
itself.  If placemat is invoked from the directory other than the
directory of YAML file, such files cannot be located.

To allow such relative paths in YAML, this commit let placemat
chdir to the directory of the first YAML given in command-line.