### PR TITLE
add copy-on-write option to Image resource

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -51,6 +51,10 @@ spec:
 - `url`: downloads an image file from specified url
 - `file`: a local file path
 - `compression`: optional field to specify decompress method.  Currently, "gzip" and "bzip2" are supported.
+- `copy-on-write`: if `true`, create a copy-on-write image based on the specified `url` or `file`.
+Only the modified data will be stored in the created image file.
+if `false`, the file copied entirely from specified `url` or `file` will be used.
+default is `false`.
 
 DataFolder resource
 -------------------

--- a/cache.go
+++ b/cache.go
@@ -49,6 +49,15 @@ func (c *cache) Put(key string, data io.Reader) error {
 }
 
 func (c *cache) Get(key string) (io.ReadCloser, error) {
+	return os.Open(c.Path(key))
+}
+
+func (c *cache) Contains(key string) bool {
+	_, err := os.Stat(c.Path(key))
+	return !os.IsNotExist(err)
+}
+
+func (c *cache) Path(key string) string {
 	ek := escapeKey(key)
-	return os.Open(filepath.Join(c.dir, ek))
+	return filepath.Join(c.dir, ek)
 }

--- a/cmd/placemat/yaml.go
+++ b/cmd/placemat/yaml.go
@@ -71,6 +71,7 @@ type imageConfig struct {
 		URL               string `yaml:"url"`
 		File              string `yaml:"file"`
 		CompressionMethod string `yaml:"compression"`
+		CopyOnWrite       bool   `yaml:"copy-on-write"`
 	} `yaml:"spec"`
 }
 
@@ -253,6 +254,7 @@ func unmarshalImage(data []byte) (*placemat.Image, error) {
 		return nil, err
 	}
 	image.Spec.Decompressor = decompressor
+	image.Spec.CopyOnWrite = dto.Spec.CopyOnWrite
 
 	return &image, nil
 }

--- a/resource.go
+++ b/resource.go
@@ -1,14 +1,13 @@
 package placemat
 
 import (
-	"net/url"
-	"path/filepath"
-
 	"context"
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
+	"path/filepath"
 	"strconv"
 
 	"github.com/cybozu-go/cmd"
@@ -58,6 +57,7 @@ type ImageSpec struct {
 	URL          *url.URL
 	File         string
 	Decompressor Decompressor
+	CopyOnWrite  bool
 }
 
 // Image represents an image configuration
@@ -108,7 +108,11 @@ func (d *DataFolder) setup(ctx context.Context) (string, error) {
 				return "", err
 			}
 		} else {
-			err = downloadData(ctx, file.URL, dstPath, nil, d.cache)
+			err = downloadData(ctx, file.URL, nil, d.cache)
+			if err != nil {
+				return "", err
+			}
+			err := copyDownloadedData(file.URL, dstPath, d.cache)
 			if err != nil {
 				return "", err
 			}
@@ -208,17 +212,33 @@ func (v *imageVolume) Create(ctx context.Context, dataDir string) ([]string, err
 
 	if needRecreate {
 		if v.image.Spec.File != "" {
-			err = writeToFile(v.image.Spec.File, p, v.image.Spec.Decompressor)
+			if v.image.Spec.CopyOnWrite {
+				err = createCoWImageFromBase(ctx, v.image.Spec.File, p)
+			} else {
+				err = writeToFile(v.image.Spec.File, p, v.image.Spec.Decompressor)
+			}
 		} else {
-			err = downloadData(ctx, v.image.Spec.URL, p, v.image.Spec.Decompressor, v.image.cache)
+			err = downloadData(ctx, v.image.Spec.URL, v.image.Spec.Decompressor, v.image.cache)
+			if err == nil {
+				if v.image.Spec.CopyOnWrite {
+					baseImage := v.image.cache.Path(v.image.Spec.URL.String())
+					err = createCoWImageFromBase(ctx, baseImage, p)
+				} else {
+					err = copyDownloadedData(v.image.Spec.URL, p, v.image.cache)
+				}
+			}
 		}
-
 		if err != nil {
 			return nil, err
 		}
 	}
 
 	return v.qemuArgs(p), nil
+}
+
+func createCoWImageFromBase(ctx context.Context, base, dest string) error {
+	c := cmd.CommandContext(ctx, "qemu-img", "create", "-f", "qcow2", "-b", base, dest)
+	return c.Run()
 }
 
 type localDSVolume struct {
@@ -455,34 +475,11 @@ func writeToFile(srcPath, destPath string, decomp Decompressor) error {
 	return err
 }
 
-func downloadData(ctx context.Context, u *url.URL, dest string, decomp Decompressor, c *cache) error {
+func downloadData(ctx context.Context, u *url.URL, decomp Decompressor, c *cache) error {
 	urlString := u.String()
-RETRY:
-	r, err := c.Get(urlString)
-	if err == nil {
-		defer r.Close()
 
-		d, err := os.OpenFile(dest, os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			return err
-		}
-		defer d.Close()
-
-		var src io.Reader = r
-		if decomp != nil {
-			newSrc, err := decomp.Decompress(src)
-			if err != nil {
-				return err
-			}
-			src = newSrc
-		}
-
-		_, err = io.Copy(d, src)
-		if err != nil {
-			return err
-		}
-
-		return d.Sync()
+	if c.Contains(urlString) {
+		return nil
 	}
 
 	req, err := http.NewRequest("GET", urlString, nil)
@@ -515,10 +512,33 @@ RETRY:
 		"size": size,
 	})
 
-	err = c.Put(urlString, res.Body)
+	var src io.Reader = res.Body
+	if decomp != nil {
+		newSrc, err := decomp.Decompress(res.Body)
+		if err != nil {
+			return err
+		}
+		src = newSrc
+	}
+
+	return c.Put(urlString, src)
+
+}
+func copyDownloadedData(u *url.URL, dest string, c *cache) error {
+	r, err := c.Get(u.String())
 	if err != nil {
 		return err
 	}
+	defer r.Close()
 
-	goto RETRY
+	d, err := os.OpenFile(dest, os.O_WRONLY|os.O_CREATE, 0644)
+	if err != nil {
+		return err
+	}
+	defer d.Close()
+	_, err = io.Copy(d, r)
+	if err != nil {
+		return err
+	}
+	return d.Sync()
 }


### PR DESCRIPTION
If copy-on-write option is true, the image will be created as copy-on-write file base on the specified file or url.
Because image files are large, it is more efficient to copy only differences.