### PR TITLE
Split cache directories from -data-dir to -cache-dir.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,17 +57,23 @@ process (by sending a signal or Control-C).
 $ placemat [OPTIONS] YAML [YAML ...]
 
 Options:
-  -nographic
-        run QEMU with no graphic
+  -graphic
+        run QEMU with graphical console
   -run-dir string
         run directory (default "/tmp")
+  -cache-dir string
+        directory for cache data.
   -data-dir string
-        directory to store data (default "$HOME/placemat_data")
+        directory to store data (default "/var/scratch/placemat")
 ```
+
+If `-cache-dir` is not specified, the default will be `/home/${SUDO_USER}/placemat_data`
+if `sudo` is used for `placemat`.  If `sudo` is not used, cache directory will be
+the same as `-data-dir`.
 
 ### placemat-connect command
 
-If placemat starts with `-nographic` option, VMs will have no graphic console.
+If placemat starts without `-graphic` option, VMs will have no graphic console.
 Instead, they have serial consoles exposed via UNIX domain sockets.
 
 `placemat-connect` is a tool to connect to the serial console.
@@ -114,7 +120,7 @@ See [examples](examples) how to write YAML files.
 To launch placemat from YAML files by the following:
 
 ```console
-$ sudo $GOPATH/bin/placemat -nographic cluster.yml
+$ sudo $GOPATH/bin/placemat cluster.yml
 ```
 
 Where `sudo` is required to create network bridge to your host.

--- a/qemu.go
+++ b/qemu.go
@@ -86,22 +86,6 @@ func (q *QemuProvider) SetupDataDir(dataDir string) error {
 		return err
 	}
 
-	imageCacheDir := filepath.Join(dataDir, "image_cache")
-	err = os.MkdirAll(imageCacheDir, 0755)
-	if err != nil {
-		return err
-	}
-
-	q.imageCache = &cache{dir: imageCacheDir}
-
-	dataCacheDir := filepath.Join(dataDir, "data_cache")
-	err = os.MkdirAll(dataCacheDir, 0755)
-	if err != nil {
-		return err
-	}
-
-	q.dataCache = &cache{dir: dataCacheDir}
-
 	tempDir := filepath.Join(dataDir, "temp")
 	err = os.MkdirAll(tempDir, 0755)
 	if err != nil {
@@ -114,6 +98,42 @@ func (q *QemuProvider) SetupDataDir(dataDir string) error {
 	q.tempDir = myTempDir
 
 	q.dataDir = dataDir
+	return nil
+}
+
+// SetupCacheDir creates directories under cacheDir for later use.
+func (q *QemuProvider) SetupCacheDir(cacheDir string) error {
+	fi, err := os.Stat(cacheDir)
+	switch {
+	case err == nil:
+		if !fi.IsDir() {
+			return errors.New(cacheDir + " is not a directory")
+		}
+	case os.IsNotExist(err):
+		err = os.MkdirAll(cacheDir, 0755)
+		if err != nil {
+			return err
+		}
+	default:
+		return err
+	}
+
+	imageCacheDir := filepath.Join(cacheDir, "image_cache")
+	err = os.MkdirAll(imageCacheDir, 0755)
+	if err != nil {
+		return err
+	}
+
+	q.imageCache = &cache{dir: imageCacheDir}
+
+	dataCacheDir := filepath.Join(cacheDir, "data_cache")
+	err = os.MkdirAll(dataCacheDir, 0755)
+	if err != nil {
+		return err
+	}
+
+	q.dataCache = &cache{dir: dataCacheDir}
+
 	return nil
 }
 


### PR DESCRIPTION
This commit adds a new command-line option "-cache-dir".
It specifies the directory for cached data.

In addition, -nographic option is replaced with -graphic
reversing the behavior.