### PR TITLE
Change Go container for CircleCI.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,14 +2,12 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/golang:1-stretch
+      - image: quay.io/cybozu/golang:1.10-bionic
     working_directory: /go/src/github.com/cybozu-go/placemat
     steps:
       - checkout
-      - run: sudo apt-get update && sudo apt-get install -y qemu-utils
-      - run: go get github.com/golang/lint/golint
-      - run: go get golang.org/x/tools/cmd/goimports
-      - run: (! $GOPATH/bin/goimports -d . 2>&1 | read _)
-      - run: test $($GOPATH/bin/golint ./... | grep -v "returns unexported type" | wc -l) -eq 0
+      - run: apt-get update && apt-get install -y qemu-utils
+      - run: (! goimports -d . 2>&1 | read _)
+      - run: test $(golint ./... | grep -v "returns unexported type" | wc -l) -eq 0
       - run: go get -v -t -d ./...
       - run: go test -race -v ./...


### PR DESCRIPTION
This commit replaces circleci/golang with our own quay.io/cybozu/golang.