### PR TITLE
Fix clean up logic for QEMU VMs.

### DIFF
--- a/bmc.go
+++ b/bmc.go
@@ -12,8 +12,6 @@ import (
 
 	"strings"
 
-	"io"
-
 	"github.com/cybozu-go/cmd"
 	"github.com/cybozu-go/log"
 	"github.com/rmxymh/infra-ecosphere/bmc"
@@ -312,36 +310,4 @@ func (w *processWriter) Write(p []byte) (n int, err error) {
 	w.sent = true
 
 	return
-}
-
-// NodeVM holds resources to manage and monitor a QEMU process.
-type NodeVM struct {
-	cmd     *cmd.LogCmd
-	monitor net.Conn
-	running bool
-}
-
-// IsRunning returns true if the VM is running.
-func (n *NodeVM) IsRunning() bool {
-	return n.running
-}
-
-// PowerOn turns on the power of the VM.
-func (n *NodeVM) PowerOn() {
-	if n.running {
-		return
-	}
-
-	io.WriteString(n.monitor, "system_reset\ncont\n")
-	n.running = true
-}
-
-// PowerOff turns off the power of the VM.
-func (n *NodeVM) PowerOff() {
-	if !n.running {
-		return
-	}
-
-	io.WriteString(n.monitor, "stop\n")
-	n.running = false
 }

--- a/cluster.go
+++ b/cluster.go
@@ -214,6 +214,11 @@ func (c *Cluster) Start(ctx context.Context, r *Runtime) error {
 	}
 	env.Stop()
 	err = env.Wait()
+	defer func() {
+		for _, vm := range vms {
+			vm.cleanup()
+		}
+	}()
 	if err != nil {
 		return err
 	}

--- a/node_vm.go
+++ b/node_vm.go
@@ -1,0 +1,41 @@
+package placemat
+
+import (
+	"io"
+	"net"
+
+	"github.com/cybozu-go/cmd"
+)
+
+// NodeVM holds resources to manage and monitor a QEMU process.
+type NodeVM struct {
+	cmd     *cmd.LogCmd
+	monitor net.Conn
+	running bool
+	cleanup func()
+}
+
+// IsRunning returns true if the VM is running.
+func (n *NodeVM) IsRunning() bool {
+	return n.running
+}
+
+// PowerOn turns on the power of the VM.
+func (n *NodeVM) PowerOn() {
+	if n.running {
+		return
+	}
+
+	io.WriteString(n.monitor, "system_reset\ncont\n")
+	n.running = true
+}
+
+// PowerOff turns off the power of the VM.
+func (n *NodeVM) PowerOff() {
+	if !n.running {
+		return
+	}
+
+	io.WriteString(n.monitor, "stop\n")
+	n.running = false
+}


### PR DESCRIPTION
Previously, garbage resources of QEMU processes was not cleaned
properly.  This commit makes sure to clean up them.