### PR TITLE
Turn on IP forwarding when NAT is enabled

### DIFF
--- a/sysctl.go
+++ b/sysctl.go
@@ -1,0 +1,47 @@
+package placemat
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const sysctlDir = "/proc/sys"
+
+func sysctlPath(name string) string {
+	return filepath.Join(sysctlDir, strings.Replace(name, ".", "/", -1))
+}
+
+// sysctlGet get the value of the named parameter from "/proc/sys".
+//
+// If this returns a non-nil error and os.IsNotExist returns true
+// for the error, the parameter is not available on this system.
+func sysctlGet(name string) (string, error) {
+	f, err := os.Open(sysctlPath(name))
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	data, err := ioutil.ReadAll(f)
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}
+
+// sysctlSet the value of the named parameter.
+//
+// If this returns a non-nil error and os.IsNotExist returns true
+// for the error, the parameter is not available on this system.
+func sysctlSet(name, value string) error {
+	f, err := os.OpenFile(sysctlPath(name), os.O_WRONLY, 0644)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	_, err = f.WriteString(value)
+	return err
+}

--- a/sysctl_test.go
+++ b/sysctl_test.go
@@ -1,0 +1,46 @@
+// build +linux
+
+package placemat
+
+import (
+	"os"
+	"testing"
+)
+
+func testSysctlGet(t *testing.T) {
+	t.Parallel()
+
+	val, err := sysctlGet("kernel.version")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Log(val)
+}
+
+func testSysctlSet(t *testing.T) {
+	if os.Getenv("TEST_SYSCTL_SET") == "" {
+		t.Skip("no TEST_SYSCTL_SET envvar")
+	}
+
+	t.Parallel()
+
+	err := sysctlSet("net.ipv4.ip_forward", "0")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	val, err := sysctlGet("net.ipv4.ip_forward")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if val != "0\n" {
+		t.Error("net.ipv4.ip_forward is not 0")
+	}
+}
+
+func TestSysctl(t *testing.T) {
+	t.Run("Get", testSysctlGet)
+	t.Run("Set", testSysctlSet)
+}


### PR DESCRIPTION
When placemat creates a NAT-enabled virtual network, it installs NAT rules to iptables.

In addition to iptables, however, the host operating system need to forward packaets
between interfaces to allow NATed connections from virtual machines.

This PR makes placemat automatically enable packet forwarding at the same time
when it installs NAT rules.  Packet forwarding is disabled when placemat exits if
they were not enabled.