### PR TITLE
add cleanup func

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,12 +72,15 @@ Options:
   -data-dir string
         directory to store data (default "/var/scratch/placemat")
   -debug
-        show QEMU's and Pod's stdout and stderr
+        show QEMU's and Pod's stdout and stderr        
+  -force
+        force run with removal of garbage
 ```
 
 If `-cache-dir` is not specified, the default will be `/home/${SUDO_USER}/placemat_data`
 if `sudo` is used for `placemat`.  If `sudo` is not used, cache directory will be
 the same as `-data-dir`.
+`-force` is used for forced run. Remaining garbage, for example virtual networks, mounts, socket files will be removed.
 
 ### placemat-connect command
 

--- a/cmd/placemat/main.go
+++ b/cmd/placemat/main.go
@@ -27,6 +27,7 @@ var (
 	flgDataDir  = flag.String("data-dir", defaultDataDir, "directory to store data")
 	flgGraphic  = flag.Bool("graphic", false, "run QEMU with graphical console")
 	flgDebug    = flag.Bool("debug", false, "show QEMU's and Pod's stdout and stderr")
+	flgForce    = flag.Bool("force", false, "force removal of the nat and network")
 )
 
 func loadClusterFromFile(p string) (*placemat.Cluster, error) {
@@ -82,7 +83,7 @@ func run(yamls []string) error {
 	runDir := os.ExpandEnv(*flgRunDir)
 	dataDir := os.ExpandEnv(*flgDataDir)
 	cacheDir := os.ExpandEnv(*flgCacheDir)
-	r, err := placemat.NewRuntime(*flgGraphic, runDir, dataDir, cacheDir)
+	r, err := placemat.NewRuntime(*flgForce, *flgGraphic, runDir, dataDir, cacheDir)
 	if err != nil {
 		return err
 	}

--- a/cmd/placemat/main.go
+++ b/cmd/placemat/main.go
@@ -27,7 +27,7 @@ var (
 	flgDataDir  = flag.String("data-dir", defaultDataDir, "directory to store data")
 	flgGraphic  = flag.Bool("graphic", false, "run QEMU with graphical console")
 	flgDebug    = flag.Bool("debug", false, "show QEMU's and Pod's stdout and stderr")
-	flgForce    = flag.Bool("force", false, "force removal of the nat and network")
+	flgForce    = flag.Bool("force", false, "force run with removal of garbage")
 )
 
 func loadClusterFromFile(p string) (*placemat.Cluster, error) {

--- a/node.go
+++ b/node.go
@@ -120,6 +120,27 @@ func (n *Node) Resolve(c *Cluster) error {
 	return nil
 }
 
+// CleanupNodes cleans files created at runtime for QEMU.
+func CleanupNodes(r *Runtime, nodes []*Node) error {
+	for _, d := range nodes {
+		files := []string{
+			r.guestSocketPath(d.Name),
+			r.monitorSocketPath(d.Name),
+			r.socketPath(d.Name),
+		}
+		for _, f := range files {
+			_, err := os.Stat(f)
+			if err == nil {
+				err = os.Remove(f)
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
 func nodeSerial(name string) string {
 	return fmt.Sprintf("%x", sha1.Sum([]byte(name)))
 }

--- a/rootfs.go
+++ b/rootfs.go
@@ -261,5 +261,5 @@ func CleanupRootfs() error {
 		}
 	}
 
-	return os.RemoveAll(rootPath)
+	return nil
 }

--- a/rootfs.go
+++ b/rootfs.go
@@ -4,8 +4,8 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
-	"path"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/cybozu-go/log"
@@ -29,6 +29,8 @@ var (
 		"pids":       true,
 	}
 )
+
+const rootPath = "/placemat-root"
 
 func umount(mp string) error {
 	return exec.Command("umount", mp).Run()
@@ -143,18 +145,17 @@ func NewRootfs() (*Rootfs, error) {
 		return nil, err
 	}
 
-	root := path.Join("/", "placemat-root")
-	err = os.MkdirAll(root, 0700)
+	err = os.MkdirAll(rootPath, 0700)
 	if err != nil {
 		return nil, err
 	}
 
-	err = bindMount("/", root)
+	err = bindMount("/", rootPath)
 	if err != nil {
 		return nil, err
 	}
 
-	mountPoints := []string{root}
+	mountPoints := []string{rootPath}
 	defer func() {
 		l := len(mountPoints)
 		for i := 0; i < l; i++ {
@@ -171,12 +172,12 @@ func NewRootfs() (*Rootfs, error) {
 		fs := fields[2]
 		options := fields[3]
 		opts := strings.Split(options, ",")
-		dest := filepath.Join(root, mp)
+		dest := filepath.Join(rootPath, mp)
 
 		switch {
 		case mp == "/":
 			continue
-		case strings.HasPrefix(mp, "/placemat-root"):
+		case strings.HasPrefix(mp, rootPath):
 			continue
 		case strings.HasPrefix(mp, "/boot"):
 			continue
@@ -226,7 +227,39 @@ func NewRootfs() (*Rootfs, error) {
 		}
 	}
 
-	ret := &Rootfs{root, mountPoints}
+	ret := &Rootfs{rootPath, mountPoints}
 	mountPoints = nil
 	return ret, nil
+}
+
+// CleanupRootfs unmount all remaining mounts.
+func CleanupRootfs() error {
+	data, err := ioutil.ReadFile("/proc/mounts")
+	if err != nil {
+		return err
+	}
+
+	var paths []string
+	for _, line := range strings.Split(string(data), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 4 {
+			continue
+		}
+		if strings.HasPrefix(fields[1], rootPath) {
+			paths = append(paths, fields[1])
+		}
+	}
+
+	sort.Sort(sort.Reverse(sort.StringSlice(paths)))
+	for _, p := range paths {
+		log.Info("unmount", map[string]interface{}{
+			"target": p,
+		})
+		err := umount(p)
+		if err != nil {
+			return err
+		}
+	}
+
+	return os.RemoveAll(rootPath)
 }

--- a/rootfs.go
+++ b/rootfs.go
@@ -4,6 +4,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -142,7 +143,8 @@ func NewRootfs() (*Rootfs, error) {
 		return nil, err
 	}
 
-	root, err := ioutil.TempDir("/", "placemat-root")
+	root := path.Join("/", "placemat-root")
+	err = os.MkdirAll(root, 0700)
 	if err != nil {
 		return nil, err
 	}

--- a/runtime.go
+++ b/runtime.go
@@ -33,6 +33,7 @@ func init() {
 
 // Runtime contains the runtime information to run Cluster.
 type Runtime struct {
+	force      bool
 	graphic    bool
 	runDir     string
 	ng         nameGenerator
@@ -43,8 +44,9 @@ type Runtime struct {
 }
 
 // NewRuntime initializes a new Runtime.
-func NewRuntime(graphic bool, runDir, dataDir, cacheDir string) (*Runtime, error) {
+func NewRuntime(force bool, graphic bool, runDir, dataDir, cacheDir string) (*Runtime, error) {
 	r := &Runtime{
+		force:   force,
 		graphic: graphic,
 		runDir:  runDir,
 		dataDir: dataDir,


### PR DESCRIPTION
### placematが強制終了されたときに残ったリソースを削除する機能を実装する
- cause
異常終了したときは正規の終了動作が行われない。

- summary
placematを実行するときに **`-force`** 引数を追加し、この場合には終了動作を行ってから実行に移る。
`$ placemat -force cluster.yml`
  - `ip tuntap delete ~ `, `ip link delete ~ ` よりip linkが削除される
  - `iptables -X ~ ` よりiptableが削除される
  - `/placemat-root/~` がunmountされる
  - `/run/netns/~` がunmountされる
  - `monitor`, `.socket`, `.guest` が削除される

- changes
  - `main.go`, `runtime,go` に`-force` パラメータを追加するためのコードを追加
  - `rootfs.go` に記述された、`/placemat-rootxxxxxxxxxxxx`のフォルダを`/placemat-root`に変更
     - 異常終了時消去するためにディレクトリ名が一意のほうが実装しやすい
     - そもそも複数存在しても以前のmountがある限り新しくmountできないため一意で良い
  - `cluster.go` にCleanupメソッドを追加
     - `destroyNatRules()`でiptablesの削除
     - `os.Remove()`での通信用`monitor`, `.socket`, `.guest`ファイルの削除
     - `deletePodNS()`でのnetnsの削除
     - `nameGenerator`でネットワーク名を検索し`n.Destroy()`でネットワークの削除
     - `/proc/mounts`からマウント情報を読み取り`/placemat-root`から始まるものを削除