### PR TITLE
Add qemu option to use para-virtualized RNG for fast boot

### DIFF
--- a/node.go
+++ b/node.go
@@ -285,6 +285,10 @@ func (n *Node) Start(ctx context.Context, r *Runtime, nodeCh chan<- bmcInfo) (*N
 	monitor := r.monitorSocketPath(n.Name)
 	params = append(params, "-monitor", "unix:"+monitor+",server,nowait")
 
+	// Random generator passthrough for fast boot
+	params = append(params, "-object", "rng-random,id=rng0,filename=/dev/urandom")
+	params = append(params, "-device", "virtio-rng-pci,rng=rng0")
+
 	log.Info("Starting VM", map[string]interface{}{"name": n.Name})
 	qemuCommand := well.CommandContext(ctx, "qemu-system-x86_64", params...)
 	qemuCommand.Stdout = newColoredLogWriter("qemu", n.Name, os.Stdout)


### PR DESCRIPTION
Ref: https://wiki.gentoo.org/wiki/QEMU/Options