### PR TITLE
ci: extend gcp instance lifetime to 30min

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,11 +18,11 @@ commands:
           command: |
             ./bin/run-mtest.sh <<parameters.suite>> <<parameters.target>>
       - run:
-          name: Set the instance lifetime to 10 minutes
+          name: Set the instance lifetime
           command: |
             . ./bin/env
             $GCLOUD compute instances add-metadata ${INSTANCE_NAME} --zone ${ZONE} \
-              --metadata shutdown-at=$(date -Iseconds -d+10minutes)
+              --metadata shutdown-at=$(date -Iseconds -d+30minutes)
           when: on_fail
       - run:
           name: Notify to Slack


### PR DESCRIPTION
Signed-off-by: UMEZAWA Takeshi <takeshi-umezawa@cybozu.co.jp>