### PR TITLE
avoid qemu warning and error when useing vvfat volume

### DIFF
--- a/node_volume.go
+++ b/node_volume.go
@@ -356,6 +356,6 @@ func (v *vvfatVolume) Create(ctx context.Context, _ string) ([]string, error) {
 func (v vvfatVolume) qemuArgs(p string) []string {
 	return []string{
 		"-drive",
-		"file=fat:16:" + p + ",format=raw,if=virtio",
+		"file=fat:16:" + p + ",format=raw,if=virtio,read-only=on",
 	}
 }


### PR DESCRIPTION
Avoid warning message like below on qemu 2.11.1.
`Opening non-rw vvfat images without an explicit read-only=on option is deprecated. Future versions will refuse to open the image instead of automatically marking the image read-only.`

And in fact Qemu 4.2.1 has come to refuse, so this fix becomes necessary.

ref. https://wiki.qemu.org/ChangeLog/3.0
> The read-only block drivers "bochs", "cloop" and "dmg" as well as "rbd" and "vvfat" in certain read-only configurations will no longer enable read-only mode automatically. It will be necessary to specify "read-only=on" explicitly on the command line and in QMP commands for the setup to keep working; the default "read-only=off" setting will result in an error.

Signed-off-by: Yuji Ito <llamerada.jp@gmail.com>