### PR TITLE
Placemat v2 Design Documents

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -51,7 +51,6 @@ apps:
 - name: dhcp-relay
   command:
   - /usr/sbin/dnsmasq
-  args: 
   - --pid-file=/var/run/dnsmasq_rack0-tor1.pid
   - --log-facility=-
   - --dhcp-relay 10.69.0.65,10.69.0.195

--- a/docs/design.md
+++ b/docs/design.md
@@ -1,0 +1,102 @@
+V2 Design Note
+==============
+
+- [Overview](#overview)
+  - [Background](#background)
+  - [Goals](#goals)
+- [NetworkNamespace Resource](#networknamespace-resource)
+- [Running Placemat2 inside a kubernetes Pod](#running-placemat2-inside-a-kubernetes-pod)
+- [New Features](#new-features)
+  - [New Package Placemat2](#new-package-placemat2)
+  - [Redfish API Support](#redfish-api-support)
+- [Obsolete Features](#obsolete-features)
+
+## Overview
+
+Placemat is a data center network and server simulation tool using QEMU/KVM virtual machines. This document elaborates the motivation and goals of Placemat v2.
+
+### Background
+
+Currently, the integration test suites of Neco, our data center management software, are running on a virtual data center built with Placemat v1 on a GCP instance, and they are unstable due to problems caused by nested VMs.
+To work around the issue, we're considering running the integration test suits in our Kubernetes cluster build on bare-metal servers instead of a GCP instance.
+
+### Goals
+
+- Remove the dependency on `rkt` because running containers inside a Kubernetes Pod is cumbersome.
+- Coexists with v1 to make the migration tasks easier.
+- Add new features and improvements
+  - Support Redfish API in Virtual BMC.
+  - Auto Path MTU discovery and configuration
+  - Improve the implementation with modern methods
+
+## NetworkNamespace Resource
+
+Placemat v2 introduces new NetworkNamespace resource and removes Pod resource because it no longer runs applications with any container engines.
+V2 creates a network namespace, executes its init-scripts, adds network interfaces, and runs applications inside the network namespace as instructed in the NetworkNamespace resource.
+Users need to be careful to set up socket files and pid files of applications such as Bird and DHCP-Relay so that they do not collide.
+For example,
+
+```yaml
+kind: NetworkStack
+name: rack0-tor1
+apps:
+- name: bird
+  command:
+  - /usr/local/bird/sbin/bird
+  args:
+  - -f
+  - -c
+  - /etc/bird/bird_rack0-tor1.conf
+  - -s
+  - /var/run/bird/bird_rack0-tor1.ctl
+- name: dhcp-relay
+  command:
+  - /usr/sbin/dnsmasq
+  args: 
+  - --pid-file=/var/run/dnsmasq_rack0-tor1.pid
+  - --log-facility=-
+  - --dhcp-relay 10.69.0.65,10.69.0.195
+  - --dhcp-relay 10.69.0.65,10.69.1.131
+interfaces:
+- addresses:
+  - 10.0.1.1/31
+  network: s1-to-r0-1
+- addresses:
+  - 10.0.1.13/31
+  network: s2-to-r0-1
+- addresses:
+  - 10.69.0.65/26
+  network: r0-node1
+```
+
+For more information, see [here](resource.md#networknamespace).
+
+## Running Placemat2 inside a Kubernetes Pod
+
+The container running Placemat v2 inside a Kubernetes Pod needs to be privileged because reading and writing `/dev/kvm` is not permitted with a not privileged container, and Kubernetes doesn't provide the feature that enables users to allow access to a specific device for now.
+See [specify hw devices in container #60748](https://github.com/kubernetes/kubernetes/issues/60748)
+
+Also, `/dev/vhost-net` needs to be exposed in the container. Run `modprobe vhost-net` on the node where you run Placemat v2.
+
+## New Package for v2
+
+The deb package for Placemat v2 is placemat2, and the binaries installed by the package are placemat2 and pmctl2 so that v1 and v2 can coexist.
+This is because we will install both Placemat v1 and v2 in the GCP image we are using for our CI, and then we will modify each application's CI.
+
+## New Features
+
+### Redfish API Support
+
+Placemat v2 supports Redfish API in addition to IPMI. For more information, see [here](virtual_bmc.md#redfish-api).
+
+### Auto path MTU discovery and configuration
+
+Placemat v2 discovers Path MTU and configures it to the links it added to fix the problem that some packets are dropped due to the lower MTU that GCP sets on its instance.
+GCP sets MTU 1460, but Placemat v1 sets MTU 1500 to the links.
+
+## Obsolete Features
+
+- Pod Resource
+  - Placemat v2 no longer depends on rkt and doesn't create pods. Use NetworkNamespace resource to create a separated network stack instead.
+- pmctl snapshot subcommand
+  - Snapshot subcommand is not used so often.

--- a/docs/pmctl.md
+++ b/docs/pmctl.md
@@ -172,7 +172,7 @@ $ pmctl node action restart node1
 
 In this subcommand you need to specify network device name.
 
-The name can be obtained with `pmclt node show` or `ip netns exec ip link` as following.
+The name can be obtained with `pmctl node show` or `ip netns exec ip link` as following.
 
 ```console
 $ DEVICE=$(pmctl node show node1 | jq -r '.taps."mynet"')

--- a/docs/pmctl.md
+++ b/docs/pmctl.md
@@ -167,53 +167,12 @@ Restart a node.
 $ pmctl node action restart node1
 ```
 
-`netns` subcommand
-------------------
-
-### `pmctl netns list [--json]`
-
-Show network namespace list.
-
-* `--json`: Show detailed information of a network namespace in JSON format.
-
-```console
-$ pmctl netns list --json | jq .
-[
-  {
-    "name": "netns1",
-    "veths": {
-      "mynet": "pm8"
-    },
-    "apps": [
-      "ubuntu"
-    ]
-  }
-]
-```
-
-### `pmctl netns show <NETWORK NS>`
-
-Show a network namespace info.
-
-```console
-$ pmctl netns show netns1 | jq .
-{
-  "name": "netns1",
-  "veths": {
-    "mynet": "pm8"
-  },
-  "apps": [
-    "ubuntu"
-  ]
-}
-```
-
 `net` subcommand
 ----------------
 
 In this subcommand you need to specify network device name.
 
-The name can be obtained with `pmclt node show` or `pmctl netns show` as following.
+The name can be obtained with `pmclt node show` or `ip netns exec ip link` as following.
 
 ```console
 $ DEVICE=$(pmctl node show node1 | jq -r '.taps."mynet"')
@@ -222,9 +181,14 @@ pm0
 ```
 
 ```console
-$ DEVICE=$(pmctl netns show netns | jq -r '.veths."mynet"')
-$ echo $DEVICE
-pm8
+# pm20 is the peer of the device eth0 inside the core network namespace, and it has been added to the bridge internet.
+$ ip netns exec core ip link
+51: eth0@if52: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP mode DEFAULT group default qlen 1000
+    link/ether f6:55:f8:08:d4:61 brd ff:ff:ff:ff:ff:ff link-netnsid 0
+
+$ ip link
+52: pm20@if51: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue master internet state UP mode DEFAULT group default qlen 1000
+    link/ether 9e:42:e4:3b:bb:34 brd ff:ff:ff:ff:ff:ff link-netnsid 10
 ```
 
 ### `pmctl net action up <DEVICE>`

--- a/docs/resource.md
+++ b/docs/resource.md
@@ -203,80 +203,45 @@ The partition need to be mounted read-only as follows:
 $ sudo mount -o ro /dev/vdb1 /mnt
 ```
 
-Pod Resource
-------------
+NetworkNamespace
+----------------
 
-Placemat creates a [rkt][] pod by a Pod resource.
-A rkt pod is a set of containers sharing a network stack (namespace).
+Placemat creates a network namespace by referencing a NetworkNamespace resource.
 
-Placemat prepares the network stack that consists of the given interfaces.
-Each network stack has its dedicated routing tables, iptables rules, etc.
+Placemat prepares the network stack that consists of the given interfaces. Each network stack has its dedicated routing tables, iptables rules, etc.
 
-In Pod's network namespace, IP-forwarding is enabled by default.
+In the network namespace, IP-forwarding is enabled by default.
 
 ```yaml
-kind: Pod
-name: my-pod
+kind: NetworkNamespace
+name: my-netns
 init-scripts:
   - /path/to/script
 interfaces:
   - network: net0
     addresses:
       - 10.0.0.1/24
-volumes:
-  - name: config
-    kind: host
-    folder: host-dir    # DataFolder resource name
-    readonly: true
-  - name: run
-    kind: empty
-    mode: "0700"
-    uid: 1000
-    gid: 1000
 apps:
   - name: bird
-    image: docker://quay.io/cybozu/bird:2.0
-    readonly-rootfs: true
-    user: 1000
-    group: 1000
-    exec: /bin/bash
-    args: ["-c", "env"]
-    env:
-      ENV1: abc
-      ENV2: def
-    mount:
-      - volume: config
-        target: /etc/bird
-      - volume: run
-        target: /run/bird
-    caps-retain:
-      - CAP_NET_ADMIN
-      - CAP_NET_BIND_SERVICE
-      - CAP_NET_RAW
+    command:
+    - /usr/local/bird/sbin/bird
+    args:
+    - -f
+    - -c
+    - /etc/bird/bird_core.conf
 ```
 
 Properties are described in the following sub sections.
 
 ### init-scripts
 
-These scripts will be executed to initialize environments before `rkt run`.
+These scripts will be executed to initialize environments before running each application inside the network namespace.
 
 ### interfaces
 
-List of network interfaces assigned to Pod.
-Each interface will be attached to a Network resource specified by
-`network`, and have IP addresses listed in `addresses`.
-
+List of network interfaces assigned to the network namespace. Each interface will be attached to a Network resource specified by `network`, and have IP addresses listed in `addresses`.
 Interfaces will be named `eth0`, `eth1`, ... in the order of definition.
-
-### volumes
-
-Volumes attached to containers.
-See [Mounting Volumes in rkt manual](https://coreos.com/rkt/docs/latest/subcommands/run.html#mounting-volumes) for details.
 
 ### apps
 
-In rkt, a container is called an app.  A pod have one or more apps.
-See [Options in rkt manual](https://coreos.com/rkt/docs/latest/subcommands/run.html#options) for details.
-
-[rkt]: https://coreos.com/rkt/
+List of applications running inside the network namespace.

--- a/docs/resource.md
+++ b/docs/resource.md
@@ -225,7 +225,6 @@ apps:
   - name: bird
     command:
     - /usr/local/bird/sbin/bird
-    args:
     - -f
     - -c
     - /etc/bird/bird_core.conf

--- a/docs/virtual_bmc.md
+++ b/docs/virtual_bmc.md
@@ -46,8 +46,9 @@ Redfish API
 
 ### Supported Resources
 
-- [Chassis](https://www.dell.com/support/manuals/ja-jp/idrac9-lifecycle-controller-v4.x-series/idrac9_4.00.00.00_redfishapiguide_pub/chassis?guid=guid-8cf4bcc2-28b2-4304-9f9e-85549fe81ee8&lang=en-us)
-- [ChassisCollection](https://www.dell.com/support/manuals/ja-jp/idrac9-lifecycle-controller-v4.x-series/idrac9_4.00.00.00_redfishapiguide_pub/chassiscollection?guid=guid-c4ac8700-44d2-46e9-b90f-67eed0774fce&lang=en-us)
+- [ChassisCollection](https://www.dell.com/support/manuals/ja-jp/idrac9-lifecycle-controller-v3.3-series/idrac9_3.36_redfishapiguide/chassiscollection?guid=guid-c4ac8700-44d2-46e9-b90f-67eed0774fce&lang=en-us)
+- [Chassis](https://www.dell.com/support/manuals/ja-jp/idrac9-lifecycle-controller-v3.3-series/idrac9_3.36_redfishapiguide/chassiscollection?guid=guid-c4ac8700-44d2-46e9-b90f-67eed0774fce&lang=en-us)
+  - [Supported Action - Reset](https://www.dell.com/support/manuals/ja-jp/idrac9-lifecycle-controller-v3.3-series/idrac9_3.36_redfishapiguide/supported-action-%E2%80%94-reset?guid=guid-eae5f0af-bfdf-4915-b097-2f6f771e5c08&lang=en-us)
 
 Placemat v2 returns the following fixed ChassisCollection.
 
@@ -59,7 +60,7 @@ Placemat v2 returns the following fixed ChassisCollection.
   "Description": "Collection of Chassis",
   "Members": [
     {
-      "@odata.id": "/redfish/v1/Chassis/1"
+      "@odata.id": "/redfish/v1/Chassis/System.Embedded.1"
     }
   ],
   "Members@odata.count": 1,
@@ -69,7 +70,23 @@ Placemat v2 returns the following fixed ChassisCollection.
 
 If you use this feature, prepare certificate files and specify command line options `-bmc-cert` and `-bmc-key`.
 
-### Authentication
+### Supported Action
 
-Placemat v2 supports Basic authentication. In this method, user name and password are provided for each Redfish API request.
-For example, `https://<USER>:<PASSWORD>@<BMC ADDRESS>/redfish/v1/Chassis` The user name and password are fixed value `cybozu`.
+Placemat V2 supports Reset Action for Chassis resource. You can confirm the supported actions in the Actions field of the Chassis Resource.
+
+```json
+{
+  "@odata.context": "/redfish/v1/$metadata#Chassis.Chassis",
+  "@odata.id": "/redfish/v1/Chassis/System.Embedded.1",
+  "@odata.type": "#Chassis.v1_6_0.Chassis",
+  "Actions": {
+    "#Chassis.Reset": {
+      "ResetType@Redfish.AllowableValues": [
+        "On",
+        "ForceOff"
+      ],
+      "target": "/redfish/v1/Chassis/System.Embedded.1/Actions/Chassis.Reset"
+    }
+  },
+}
+```

--- a/docs/virtual_bmc.md
+++ b/docs/virtual_bmc.md
@@ -4,10 +4,8 @@ Virtual BMC
 Overview
 --------
 
-Placemat provides virtual BMC functionality.
-Users in a placemat node can control other nodes via BMCs.
-They can, for example, power-on/off nodes, reset nodes, and retrieve info
-of nodes by communicating with BMCs.
+Placemat provides virtual BMC functionality. Users in a placemat node can control other nodes via BMCs.
+They can, for example, power-on/off nodes, reset nodes, and retrieve info of nodes by communicating with BMCs.
 
 The address range of BMC network should be given in a resources YAML file.
 
@@ -39,12 +37,39 @@ How it works
 Supported IPMI commands
 -----------------------
 
-(TBD)
+- Chassis Power On
+- Chassis Power Off
+- Chassis Power Reset / Cycle
 
-HTTPS server
-------------
+Redfish API
+-----------
 
-For test purpose, Placemat deploys HTTPS servers on `https://<BMC address>:443`.
-They return 200 OK only.
+### Supported Resources
+
+- [Chassis](https://www.dell.com/support/manuals/ja-jp/idrac9-lifecycle-controller-v4.x-series/idrac9_4.00.00.00_redfishapiguide_pub/chassis?guid=guid-8cf4bcc2-28b2-4304-9f9e-85549fe81ee8&lang=en-us)
+- [ChassisCollection](https://www.dell.com/support/manuals/ja-jp/idrac9-lifecycle-controller-v4.x-series/idrac9_4.00.00.00_redfishapiguide_pub/chassiscollection?guid=guid-c4ac8700-44d2-46e9-b90f-67eed0774fce&lang=en-us)
+
+Placemat v2 returns the following fixed ChassisCollection.
+
+```json
+{
+  "@odata.context": "/redfish/v1/$metadata#ChassisCollection.ChassisCollection",
+  "@odata.id": "/redfish/v1/Chassis/",
+  "@odata.type": "#ChassisCollection.ChassisCollection",
+  "Description": "Collection of Chassis",
+  "Members": [
+    {
+      "@odata.id": "/redfish/v1/Chassis/1"
+    }
+  ],
+  "Members@odata.count": 1,
+  "Name": "Chassis Collection"
+}
+```
 
 If you use this feature, prepare certificate files and specify command line options `-bmc-cert` and `-bmc-key`.
+
+### Authentication
+
+Placemat v2 supports Basic authentication. In this method, user name and password are provided for each Redfish API request.
+For example, `https://<USER>:<PASSWORD>@<BMC ADDRESS>/redfish/v1/Chassis` The user name and password are fixed value `cybozu`.

--- a/docs/virtual_bmc.md
+++ b/docs/virtual_bmc.md
@@ -68,8 +68,6 @@ Placemat v2 returns the following fixed ChassisCollection.
 }
 ```
 
-If you use this feature, prepare certificate files and specify command line options `-bmc-cert` and `-bmc-key`.
-
 ### Supported Action
 
 Placemat V2 supports Reset Action for Chassis resource. You can confirm the supported actions in the Actions field of the Chassis Resource.


### PR DESCRIPTION
This PR adds v2 design documents that cover the following topics.

- Remove the dependency on `rkt`
- Running Placemat inside a Kubernetes Pod
- Virtual BMC supports Redfish API