### PR TITLE
dcnet: detect MTU by "ip route get"

### DIFF
--- a/v2/pkg/dcnet/mtu.go
+++ b/v2/pkg/dcnet/mtu.go
@@ -2,13 +2,53 @@ package dcnet
 
 import (
 	"fmt"
+	"net"
 
 	"github.com/vishvananda/netlink"
 )
 
-// DetectMTU returns the _minimum_ MTU value of the physical network links.
-// This may return zero if it cannot detect any physical link or encounters an error.
-func DetectMTU() (int, error) {
+func detectByRouteGet() (int, error) {
+	// 192.0.0.10 is a special globally reachable IPv4 address described in RFC8155.
+	// Likewise, 2001:1::2/128 is a special IPv6 address described in the same RFC.
+	// https://tools.ietf.org/html/rfc8155
+	routes, err := netlink.RouteGet(net.ParseIP("192.0.0.10"))
+	if len(routes) == 0 {
+		routes, err = netlink.RouteGet(net.ParseIP("2001:1::2/128"))
+	}
+	if err != nil {
+		return 0, err
+	}
+
+	mtu := 0
+	for _, r := range routes {
+		if r.LinkIndex == 0 {
+			continue
+		}
+
+		link, err := netlink.LinkByIndex(r.LinkIndex)
+		if err != nil {
+			return 0, err
+		}
+
+		lmtu := link.Attrs().MTU
+		if lmtu == 0 {
+			continue
+		}
+
+		if mtu == 0 {
+			mtu = lmtu
+			continue
+		}
+
+		if lmtu < mtu {
+			mtu = lmtu
+		}
+	}
+
+	return mtu, nil
+}
+
+func detectFromPhysLinks() (int, error) {
 	links, err := netlink.LinkList()
 	if err != nil {
 		return 0, fmt.Errorf("netlink: failed to list links: %w", err)
@@ -18,12 +58,10 @@ func DetectMTU() (int, error) {
 	for _, link := range links {
 		dev, ok := link.(*netlink.Device)
 		if !ok {
-			//fmt.Println("skipping non device", link.Attrs().Name)
 			continue
 		}
 
 		if dev.Attrs().OperState != netlink.OperUp {
-			//fmt.Println("skipping down link", dev.Name)
 			continue
 		}
 
@@ -42,4 +80,14 @@ func DetectMTU() (int, error) {
 	}
 
 	return mtu, nil
+}
+
+// DetectMTU returns the right MTU value for communications to the Internet.
+// This may return zero if it fails to detect MTU.
+func DetectMTU() (int, error) {
+	mtu, err := detectByRouteGet()
+	if mtu == 0 {
+		mtu, err = detectFromPhysLinks()
+	}
+	return mtu, err
 }


### PR DESCRIPTION
The new implementation first tries to detect the right device
used for communication to the Internet.  If there is no such
device, it returns the minimum MTU of the physical links.