### PR TITLE
Fix BMC server startup failure

### DIFF
--- a/v2/pkg/virtualbmc/bmc_server_test.go
+++ b/v2/pkg/virtualbmc/bmc_server_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"os"
 
 	"github.com/cybozu-go/well"
 	. "github.com/onsi/ginkgo"
@@ -116,12 +115,9 @@ var _ = Describe("Virtual BMC", func() {
 		listener, err := net.ListenTCP("tcp", addr)
 		Expect(err).NotTo(HaveOccurred())
 
-		cur, err := os.Getwd()
-		Expect(err).NotTo(HaveOccurred())
-
 		env := well.NewEnvironment(context.Background())
 		env.Go(func(ctx context.Context) error {
-			return StartRedfishServer(ctx, listener, cur, &MachineMock{status: PowerStatusOff})
+			return StartRedfishServer(ctx, listener, &MachineMock{status: PowerStatusOff})
 		})
 
 		By("Retrieving a ComputerSystem resource and manipulate it")

--- a/v2/pkg/virtualbmc/gencert.go
+++ b/v2/pkg/virtualbmc/gencert.go
@@ -8,16 +8,14 @@ import (
 	"encoding/pem"
 	"fmt"
 	"math/big"
-	"os"
-	"path/filepath"
 	"strings"
 	"time"
 )
 
-func generateCertificate(host, outDir string, validFor time.Duration) (string, string, error) {
+func generateCertificate(host string, validFor time.Duration) ([]byte, []byte, error) {
 	priv, err := rsa.GenerateKey(rand.Reader, 4096)
 	if err != nil {
-		return "", "", fmt.Errorf("failed to generate key: %w", err)
+		return nil, nil, fmt.Errorf("failed to generate key: %w", err)
 	}
 
 	keyUsage := x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment
@@ -39,36 +37,16 @@ func generateCertificate(host, outDir string, validFor time.Duration) (string, s
 
 	certBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, priv.Public(), priv)
 	if err != nil {
-		return "", "", fmt.Errorf("failed to create certificate: %w", err)
-	}
-
-	_, err = os.Stat(outDir)
-	switch {
-	case err == nil:
-	case os.IsNotExist(err):
-		err = os.MkdirAll(outDir, 0755)
-		if err != nil {
-			return "", "", fmt.Errorf("failed to create output directory: %w", err)
-		}
-	default:
-		return "", "", fmt.Errorf("stat %s failed: %w", outDir, err)
+		return nil, nil, fmt.Errorf("failed to create certificate: %w", err)
 	}
 
 	privBytes, err := x509.MarshalPKCS8PrivateKey(priv)
 	if err != nil {
-		return "", "", fmt.Errorf("failed to marshal private key: %w", err)
+		return nil, nil, fmt.Errorf("failed to marshal private key: %w", err)
 	}
 
-	cert := filepath.Join(outDir, "cert.pem")
-	if err := outputPEM(cert, "CERTIFICATE", certBytes); err != nil {
-		return "", "", err
-	}
-	key := filepath.Join(outDir, "key.pem")
-	if err := outputPEM(key, "PRIVATE KEY", privBytes); err != nil {
-		return "", "", err
-	}
-
-	return cert, key, nil
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certBytes}),
+		pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: privBytes}), nil
 }
 
 func dnsAliases(host string) []string {
@@ -78,24 +56,4 @@ func dnsAliases(host string) []string {
 		aliases[i] = strings.Join(parts[0:len(parts)-i], ".")
 	}
 	return aliases
-}
-
-func outputPEM(fname string, pemType string, data []byte) error {
-	f, err := os.OpenFile(fname, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
-	if err != nil {
-		return fmt.Errorf("failed to open %s: %w", fname, err)
-	}
-	defer f.Close()
-
-	err = pem.Encode(f, &pem.Block{Type: pemType, Bytes: data})
-	if err != nil {
-		return fmt.Errorf("failed to encode: %w", err)
-	}
-
-	err = f.Sync()
-	if err != nil {
-		return fmt.Errorf("failed to fsync: %w", err)
-	}
-
-	return nil
 }

--- a/v2/pkg/vm/bmc.go
+++ b/v2/pkg/vm/bmc.go
@@ -23,15 +23,13 @@ type bmcServer struct {
 	nodeCh   <-chan BMCInfo
 	networks []dcnet.Network
 	vms      map[string]VM // key: serial
-	tempDir  string
 }
 
 // NewBMCServer creates a BMCServer instance
-func NewBMCServer(vms map[string]VM, networks []dcnet.Network, ch <-chan BMCInfo, tempDir string) BMCServer {
+func NewBMCServer(vms map[string]VM, networks []dcnet.Network, ch <-chan BMCInfo) BMCServer {
 	s := &bmcServer{
-		nodeCh:  ch,
-		vms:     vms,
-		tempDir: tempDir,
+		nodeCh: ch,
+		vms:    vms,
 	}
 	for _, n := range networks {
 		if n.IsType(types.NetworkBMC) {
@@ -94,7 +92,7 @@ OUTER:
 				})
 			}
 			env.Go(func(ctx context.Context) error {
-				return virtualbmc.StartRedfishServer(ctx, listener, s.tempDir, s.vms[info.serial])
+				return virtualbmc.StartRedfishServer(ctx, listener, s.vms[info.serial])
 			})
 
 		case <-ctx.Done():

--- a/v2/pkg/vm/runtime.go
+++ b/v2/pkg/vm/runtime.go
@@ -3,7 +3,6 @@ package vm
 import (
 	"bufio"
 	"errors"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -47,7 +46,6 @@ type Runtime struct {
 	Graphic    bool
 	RunDir     string
 	DataDir    string
-	TempDir    string
 	ListenAddr string
 	ImageCache *util.Cache
 }
@@ -111,17 +109,6 @@ func NewRuntime(force, graphic bool, runDir, dataDir, cacheDir, listenAddr strin
 	if err != nil {
 		return nil, err
 	}
-
-	tempDir := filepath.Join(dataDir, "temp")
-	err = os.MkdirAll(tempDir, 0755)
-	if err != nil {
-		return nil, err
-	}
-	myTempDir, err := ioutil.TempDir(tempDir, "")
-	if err != nil {
-		return nil, err
-	}
-	r.TempDir = myTempDir
 
 	return r, nil
 }


### PR DESCRIPTION
This PR fixes the BMC server error caused by the TLS certificates conflict. BMC servers write certificates on the same directory and that leads to the server startup failure. Placemat no longer generates certificate files with this PR.