### PR TITLE
Fix Internal Server Error when vm's power status cannot be confirmed

### DIFF
--- a/bin/env
+++ b/bin/env
@@ -1,5 +1,5 @@
 PROJECT=neco-test
-ZONE=asia-northeast2-c
+ZONE=asia-northeast1-c
 SERVICE_ACCOUNT=neco-test@neco-test.iam.gserviceaccount.com
 INSTANCE_NAME=$(echo "$GITHUB_REPOSITORY" | awk -F / '{print $2}')-${GITHUB_RUN_NUMBER}-$(date "+%Y%m%d-%H%M%S")
 MACHINE_TYPE=n1-standard-8

--- a/v2/e2e/placemat_test.go
+++ b/v2/e2e/placemat_test.go
@@ -67,6 +67,29 @@ var _ = Describe("Placemat", func() {
 			}).Should(Succeed())
 		})
 
+		By("serving node statuses", func() {
+			var statuses []placemat.NodeStatus
+			Eventually(func() error {
+				stdout, err := pmctl("node", "list", "--json")
+				if err != nil {
+					return err
+				}
+				err = json.Unmarshal(stdout, &statuses)
+				if err != nil {
+					return err
+				}
+				if len(statuses) != 2 {
+					return fmt.Errorf("statutes length should be 2 actual: %d", len(statuses))
+				}
+				for i, status := range statuses {
+					if status.PowerStatus != virtualbmc.PowerStatusOn {
+						return fmt.Errorf("node%d is not running", i+1)
+					}
+				}
+				return nil
+			}).Should(Succeed())
+		})
+
 		By("mounting vdc (raw volume, qcow2 format)", func() {
 			_, _, err := execAt(node1, "sudo", "dd", "if=/dev/zero", "of=/dev/vdc", "bs=1M", "count=1")
 			Expect(err).NotTo(HaveOccurred())

--- a/v2/pkg/placemat/server.go
+++ b/v2/pkg/placemat/server.go
@@ -84,24 +84,13 @@ func (s *apiServer) handleNode(c *gin.Context) {
 		c.JSON(http.StatusNotFound, nil)
 		return
 	}
-	status, err := newNodeStatus(spec, s.cluster.nodeMap[name], s.cluster.vms[spec.SMBIOS.Serial], s.runtime)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, nil)
-		return
-	}
-
-	c.JSON(http.StatusOK, status)
+	c.JSON(http.StatusOK, newNodeStatus(spec, s.cluster.nodeMap[name], s.cluster.vms[spec.SMBIOS.Serial], s.runtime))
 }
 
 func (s *apiServer) handleNodes(c *gin.Context) {
 	statuses := make([]*NodeStatus, len(s.cluster.nodeSpecs))
 	for i, spec := range s.cluster.nodeSpecs {
-		status, err := newNodeStatus(spec, s.cluster.nodeMap[spec.Name], s.cluster.vms[spec.SMBIOS.Serial], s.runtime)
-		if err != nil {
-			c.JSON(http.StatusInternalServerError, nil)
-			return
-		}
-		statuses[i] = status
+		statuses[i] = newNodeStatus(spec, s.cluster.nodeMap[spec.Name], s.cluster.vms[spec.SMBIOS.Serial], s.runtime)
 	}
 	c.JSON(http.StatusOK, statuses)
 }
@@ -145,10 +134,10 @@ func (s *apiServer) handleNodeAction(c *gin.Context) {
 	c.JSON(http.StatusOK, nil)
 }
 
-func newNodeStatus(spec *types.NodeSpec, node vm.Node, vm vm.VM, runtime *vm.Runtime) (*NodeStatus, error) {
+func newNodeStatus(spec *types.NodeSpec, node vm.Node, vm vm.VM, runtime *vm.Runtime) *NodeStatus {
 	powerStatus, err := vm.PowerStatus()
 	if err != nil {
-		return nil, err
+		log.Error("failed to confirm vm's power status", map[string]interface{}{log.FnError: err})
 	}
 
 	status := &NodeStatus{
@@ -170,5 +159,5 @@ func newNodeStatus(spec *types.NodeSpec, node vm.Node, vm vm.VM, runtime *vm.Run
 	for i, v := range spec.Volumes {
 		status.Volumes[i] = v.Name
 	}
-	return status, nil
+	return status
 }

--- a/v2/pkg/placemat/server.go
+++ b/v2/pkg/placemat/server.go
@@ -105,24 +105,24 @@ func (s *apiServer) handleNodeAction(c *gin.Context) {
 		return
 	}
 
-	vm := s.cluster.vms[spec.SMBIOS.Serial]
+	v := s.cluster.vms[spec.SMBIOS.Serial]
 	switch action {
 	case "start":
-		if err := vm.PowerOn(); err != nil {
+		if err := v.PowerOn(); err != nil {
 			c.JSON(http.StatusInternalServerError, nil)
 			return
 		}
 	case "stop":
-		if err := vm.PowerOff(); err != nil {
+		if err := v.PowerOff(); err != nil {
 			c.JSON(http.StatusInternalServerError, nil)
 			return
 		}
 	case "restart":
-		if err := vm.PowerOff(); err != nil {
+		if err := v.PowerOff(); err != nil {
 			c.JSON(http.StatusInternalServerError, nil)
 			return
 		}
-		if err := vm.PowerOn(); err != nil {
+		if err := v.PowerOn(); err != nil {
 			c.JSON(http.StatusInternalServerError, nil)
 			return
 		}

--- a/v2/pkg/placemat/server.go
+++ b/v2/pkg/placemat/server.go
@@ -109,20 +109,24 @@ func (s *apiServer) handleNodeAction(c *gin.Context) {
 	switch action {
 	case "start":
 		if err := v.PowerOn(); err != nil {
+			log.Error("failed to power on", map[string]interface{}{log.FnError: err})
 			c.JSON(http.StatusInternalServerError, nil)
 			return
 		}
 	case "stop":
 		if err := v.PowerOff(); err != nil {
+			log.Error("failed to power off", map[string]interface{}{log.FnError: err})
 			c.JSON(http.StatusInternalServerError, nil)
 			return
 		}
 	case "restart":
 		if err := v.PowerOff(); err != nil {
+			log.Error("failed to power off during restart", map[string]interface{}{log.FnError: err})
 			c.JSON(http.StatusInternalServerError, nil)
 			return
 		}
 		if err := v.PowerOn(); err != nil {
+			log.Error("failed to power on during restart", map[string]interface{}{log.FnError: err})
 			c.JSON(http.StatusInternalServerError, nil)
 			return
 		}

--- a/v2/pkg/virtualbmc/bmc_server.go
+++ b/v2/pkg/virtualbmc/bmc_server.go
@@ -28,7 +28,7 @@ const (
 	PowerStatusPoweringOn  = PowerStatus("PoweringOn")
 	PowerStatusOff         = PowerStatus("Off")
 	PowerStatusPoweringOff = PowerStatus("PoweringOff")
-	PowerStatusUnknown     = PowerStatus("")
+	PowerStatusUnknown     = PowerStatus("Unknown")
 )
 
 // StartIPMIServer starts an ipmi server that handles RMCP requests


### PR DESCRIPTION
This PR fixes the internal server error that aborts node list command when vm's powers status cannot be confirmed.  `pmctl2 node list` lists VM list without showing internal server error.  `pmctl2 node show` shows `power_Status: Unknown` as follows.

```
$ pmctl2 node show boot-0 | jq .
{
  "name": "boot-0",
  "taps": {
    "r0-node1": "pm_tap04562b3f",
    "r0-node2": "pm_tap61b6b82f"
  },
  "volumes": [
    "root",
    "seed",
    "sabakan"
  ],
  "cpu": 8,
  "memory": "4G",
  "uefi": false,
  "tpm": false,
  "smbios": {
    "manufacturer": "",
    "product": "",
    "serial": "fb8f2417d0b4db30050719c31ce02a2e8141bbd8"
  },
  "power_status": "Unknown",
  "socket_path": "/tmp/boot-0.socket"
}
```