### PR TITLE
Fix the permission error

### DIFF
--- a/v2/pkg/vm/qemu.go
+++ b/v2/pkg/vm/qemu.go
@@ -189,7 +189,7 @@ type localDSVolumeArgs struct {
 func (v *localDSVolumeArgs) args() []string {
 	return []string{
 		"-drive",
-		fmt.Sprintf("if=virtio,cache=%s,aio=%s,format=raw,file=%s", v.cache, selectAIOforCache(v.cache), v.volumePath),
+		fmt.Sprintf("if=virtio,cache=%s,aio=%s,format=qcow2,file=%s", v.cache, selectAIOforCache(v.cache), v.volumePath),
 	}
 }
 

--- a/v2/pkg/vm/qemu_test.go
+++ b/v2/pkg/vm/qemu_test.go
@@ -153,7 +153,7 @@ qemu-system-x86_64
  -netdev tap,id=r0-node2,ifname=%s,script=no,downscript=no,vhost=on
  -device virtio-net-pci,host_mtu=1460,netdev=r0-node2,mac=placemat
  -drive if=virtio,cache=writeback,aio=threads,file=%s/root.img
- -drive if=virtio,cache=none,aio=native,format=raw,file=%s/seed.img
+ -drive if=virtio,cache=none,aio=native,format=qcow2,file=%s/seed.img
  -virtfs local,path=%s,mount_tag=sabakan,security_model=none,readonly
  -boot reboot-timeout=30000
  -chardev socket,id=char0,path=%s/boot-0.guest,server,nowait
@@ -303,7 +303,7 @@ qemu-system-x86_64
  -netdev tap,id=r0-node2,ifname=%s,script=no,downscript=no,vhost=on
  -device virtio-net-pci,host_mtu=1460,netdev=r0-node2,mac=placemat,romfile=
  -drive if=virtio,cache=writeback,aio=threads,file=%s/root.img
- -drive if=virtio,cache=none,aio=native,format=raw,file=%s/seed.img
+ -drive if=virtio,cache=none,aio=native,format=qcow2,file=%s/seed.img
  -virtfs local,path=%s,mount_tag=sabakan,security_model=none,readonly
  -chardev socket,id=chrtpm,path=%s/boot-0/swtpm.socket
  -tpmdev emulator,id=tpm0,chardev=chrtpm

--- a/v2/pkg/vm/volume.go
+++ b/v2/pkg/vm/volume.go
@@ -189,7 +189,7 @@ func (v *localDSVolume) create(ctx context.Context, dataDir string) (volumeArgs,
 				return nil, err
 			}
 		} else {
-			err := well.CommandContext(ctx, "cloud-localds", vPath, v.userData, "--network-config", v.networkConfig).Run()
+			err := well.CommandContext(ctx, "cloud-localds", vPath, v.userData, "--network-config", v.networkConfig, "--disk-format", "qcow2").Run()
 			if err != nil {
 				return nil, err
 			}

--- a/v2/pkg/vm/volume_test.go
+++ b/v2/pkg/vm/volume_test.go
@@ -100,7 +100,7 @@ smbios:
 		Expect(err).NotTo(HaveOccurred())
 		Expect(args.args()).To(Equal([]string{
 			"-drive",
-			fmt.Sprintf("if=virtio,cache=none,aio=native,format=raw,file=%s/seed.img", temp),
+			fmt.Sprintf("if=virtio,cache=none,aio=native,format=qcow2,file=%s/seed.img", temp),
 		}))
 		_, err = os.Stat(filepath.Join(temp, "seed.img"))
 		Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
QEMU raises the permission error "Cannot get 'write' permission without 'resize': Image size is not a multiple of request alignment",
if a target image is not 4k aligned, and WRITE permission is granted but RESIZE is not.
To work around the issue, we change the localds image fomat from raw to qcow2 not to generate an unaligned seed image.

See
https://github.com/qemu/qemu/commit/9c60a5d1978e6dcf85c0e01b50e6f7f54ca09104
https://bugs.launchpad.net/ubuntu/+source/qemu/+bug/1921665

Signed-off-by: Yusuke Suzuki <yusuke-suzuki@cybozu.co.jp>