### PR TITLE
Support multiple device backends for placemat VMs

### DIFF
--- a/docs/resource.md
+++ b/docs/resource.md
@@ -8,6 +8,7 @@ Following resources are available.
 * Image
 * Node
 * NetworkNamespace
+* DeviceClass
 
 Network resource
 ----------------
@@ -73,6 +74,7 @@ volumes:
   - kind: raw
     name: data
     size: 10G
+    device-class: ssd
   - kind: hostPath
     name: host-data
     path: /var/lib/foo
@@ -113,6 +115,7 @@ The properties are:
 * `kind`: kind of the volume.  Required.
 * `name`: name of the volume.  Required.
 * `cache`: determine how to access backend storage. Possible values are `writeback`, `none`, `writethrough`, `directsync`, `unsafe`.  Defaulted to `none`.
+* `device-class`: determine where to locate backend storage. Possible values are defined in `DeviceClass` resource. If this field isn't set, unnamed device class will be assined and default path will be used.
 
 ### `image` volume
 
@@ -198,3 +201,18 @@ Interfaces will be named `eth0`, `eth1`, ... in the order of definition.
 ### apps
 
 List of applications running inside the network namespace.
+
+DeviceClass resource
+--------------------
+
+Placemat creates backend storage at the location specified by this resource.
+
+```yaml
+kind: DeviceClass
+name: ssd
+path: /var/scratch/ssd
+```
+
+The properties are:
+
+- `path`: The path to locate backend storage.

--- a/examples/cluster.example.yml
+++ b/examples/cluster.example.yml
@@ -14,6 +14,10 @@ kind: Image
 name: ubuntu-image
 url: https://cloud-images.ubuntu.com/releases/20.04/release/ubuntu-20.04-server-cloudimg-amd64.img
 ---
+kind: DeviceClass
+name: ssd
+path: /var/scratch/ssd
+---
 kind: Node
 name: boot
 interfaces:
@@ -51,6 +55,7 @@ volumes:
   - kind: raw
     name: data
     size: 10G
+    device-class: ssd
 cpu: 1
 memory: 2G
 smbios:

--- a/v2/pkg/placemat/cluster.go
+++ b/v2/pkg/placemat/cluster.go
@@ -21,30 +21,32 @@ type Cluster interface {
 }
 
 type cluster struct {
-	networkSpecs []*types.NetworkSpec
-	netNSSpecs   []*types.NetNSSpec
-	nodeSpecs    []*types.NodeSpec
-	imageSpecs   []*types.ImageSpec
-	networks     []dcnet.Network
-	netNss       []dcnet.NetNS
-	nodes        []vm.Node
-	vms          map[string]vm.VM
-	networkMap   map[string]dcnet.Network
-	nodeSpecMap  map[string]*types.NodeSpec
-	nodeMap      map[string]vm.Node
+	networkSpecs     []*types.NetworkSpec
+	netNSSpecs       []*types.NetNSSpec
+	deviceClassSpecs []*types.DeviceClassSpec
+	nodeSpecs        []*types.NodeSpec
+	imageSpecs       []*types.ImageSpec
+	networks         []dcnet.Network
+	netNss           []dcnet.NetNS
+	nodes            []vm.Node
+	vms              map[string]vm.VM
+	networkMap       map[string]dcnet.Network
+	nodeSpecMap      map[string]*types.NodeSpec
+	nodeMap          map[string]vm.Node
 }
 
 // NewCluster creates a Cluster from spec.
 func NewCluster(spec *types.ClusterSpec) (*cluster, error) {
 	cluster := &cluster{
-		networkSpecs: spec.Networks,
-		netNSSpecs:   spec.NetNSs,
-		nodeSpecs:    spec.Nodes,
-		imageSpecs:   spec.Images,
-		vms:          make(map[string]vm.VM),
-		networkMap:   make(map[string]dcnet.Network),
-		nodeSpecMap:  make(map[string]*types.NodeSpec),
-		nodeMap:      make(map[string]vm.Node),
+		networkSpecs:     spec.Networks,
+		netNSSpecs:       spec.NetNSs,
+		deviceClassSpecs: spec.DeviceClasses,
+		nodeSpecs:        spec.Nodes,
+		imageSpecs:       spec.Images,
+		vms:              make(map[string]vm.VM),
+		networkMap:       make(map[string]dcnet.Network),
+		nodeSpecMap:      make(map[string]*types.NodeSpec),
+		nodeMap:          make(map[string]vm.Node),
 	}
 
 	for _, node := range cluster.nodeSpecs {
@@ -86,7 +88,7 @@ func (c *cluster) Setup(ctx context.Context, r *vm.Runtime) error {
 	}
 
 	for _, spec := range c.nodeSpecs {
-		node, err := vm.NewNode(spec, c.imageSpecs)
+		node, err := vm.NewNode(spec, c.imageSpecs, c.deviceClassSpecs)
 		if err != nil {
 			return err
 		}

--- a/v2/pkg/vm/qemu_test.go
+++ b/v2/pkg/vm/qemu_test.go
@@ -106,10 +106,10 @@ use-nat: false
 		// Create volumes
 		var volumeArgs []volumeArgs
 		for _, volumeSpec := range nodeSpec.Volumes {
-			volume, err := newNodeVolume(volumeSpec, cluster.Images)
+			volume, err := newNodeVolume(volumeSpec, cluster.Images, cluster.DeviceClasses)
 			Expect(err).NotTo(HaveOccurred())
 
-			args, err := volume.create(context.Background(), r.DataDir)
+			args, err := volume.create(context.Background(), r.DataDir, "")
 			Expect(err).NotTo(HaveOccurred())
 			volumeArgs = append(volumeArgs, args)
 		}
@@ -255,10 +255,10 @@ use-nat: false
 		// Create volumes
 		var volumeArgs []volumeArgs
 		for _, volumeSpec := range nodeSpec.Volumes {
-			volume, err := newNodeVolume(volumeSpec, cluster.Images)
+			volume, err := newNodeVolume(volumeSpec, cluster.Images, cluster.DeviceClasses)
 			Expect(err).NotTo(HaveOccurred())
 
-			args, err := volume.create(context.Background(), r.DataDir)
+			args, err := volume.create(context.Background(), r.DataDir, "")
 			Expect(err).NotTo(HaveOccurred())
 			volumeArgs = append(volumeArgs, args)
 		}


### PR DESCRIPTION
This PR implements multiple device backends supports for placemat VMs.

Users can use multiple device backends by specifying DeviceClass as follows.

```
kind: DeviceClass
name: ssd
path: /var/scratch/ssd
---
kind: Node
volumes:
- cache: none
  format: raw
  kind: raw
  name: data1
  size: 50G
  deviceClass: ssd
```

issue: cybozu/csa#62
Signed-off-by: Yuma Ogami <yuma-ogami@cybozu.co.jp>
Signed-off-by: Shinya Hayashi <shinya-hayashi@cybozu.co.jp>