### PR TITLE
Update version.go to 2.4.2

### DIFF
--- a/v2/version.go
+++ b/v2/version.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 )
 
-const version = "2.4.1"
+const version = "2.4.2"
 
 // Version returns the semantic versioning string of Coil.
 func Version() string {


### PR DESCRIPTION
I forgot to update version.go in https://github.com/cybozu-go/placemat/pull/184 PR, so only version.go is updated.
Signed-off-by: zeroalphat <taichi-takemura@cybozu.co.jp>